### PR TITLE
fix: issue #18 hero 终端 → AI agent 会话演出（pi.dev 风格）

### DIFF
--- a/src/components/HeroTerminal.tsx
+++ b/src/components/HeroTerminal.tsx
@@ -1,37 +1,40 @@
-import { Fragment, type CSSProperties, type ReactNode } from 'react'
+import { type CSSProperties, type ReactNode } from 'react'
 
 /**
- * hero 终端（issue #13，PRD #8 hero 终端切片）：
- * 站点名下方展示数据驱动的命令流终端窗口，让读者第一眼认识作者与站点气质。
+ * hero 终端（issue #18，父 PRD #16）：pi.dev 风格 AI agent 会话演出。
  *
  * 设计决策：
- * - 内容由「命令 + 输出 + 是否打字机」的数据结构驱动（TerminalCommand[]），
- *   文章数/标签数等由调用方从内容清单自动计算——新增文章/命令无需改渲染代码
- * - 打字机为纯 CSS 行为（clip-path + steps 逐字符揭示）：SSR 与客户端首帧都渲染
- *   完整 tagline 文本（预渲染 HTML 含全文、SEO 不回归、无 hydration mismatch），
- *   prefers-reduced-motion 时 media query 直接禁用动画显示完整文本，无 JS 报错
- * - 每行命令带 `$` 提示符；终端输出统一使用 --color-terminal 令牌
- *   （灰阶值，随亮暗主题切换）；行尾闪烁块状光标
+ * - 数据模型为「对话轮次」（TerminalTurn：❓ user 提问 / ▲ tool 工具调用 /
+ *   assistant 回答），不再是「命令 + 输出」——文章数/标签数等仍由调用方从站点
+ *   信息与内容清单自动计算，新增文章无需改渲染代码
+ * - 终端框架（pi.dev 风格）：恒黑底白字（亮暗模式均如此，与页面 chrome 主题色
+ *   解耦）、四角括号装饰（┌┐└┘）、底部 caption（● live 红点 + 弱化 mono 文字）；
+ *   移除 mac 装饰圆点窗口栏（PostCard 的 ●●● 标题栏不受影响，复用 terminal-dot）
+ * - 演出编排为纯 CSS：逐段入场（轮次按 --i * --turn-gap 依次错开）、tagline 打字机
+ *   （clip-path + steps）、tool 块灰阶脉冲、live 点脉冲；全部自动播放一遍后停在
+ *   最终态、不循环；SSR 与客户端首帧都渲染完整对话文本（预渲染 HTML 含全文、
+ *   SEO 不回归、无 hydration mismatch），prefers-reduced-motion 时 media query
+ *   整体禁用动画、全文直接可见，无 JS 报错
  */
 
-/** 终端命令数据：驱动 hero 终端逐行渲染（命令 + 输出 + 是否打字机） */
-export interface TerminalCommand {
-  /** 命令文本（渲染为 `$ <command>`） */
-  command: string
-  /** 命令输出：文本或含链接的节点（终端输出统一 text-terminal 绿） */
-  output: ReactNode
-  /** 打字机逐字输出（仅 tagline）：SSR 仍渲染完整文本，动画为纯 CSS */
-  typewriter?: boolean
-}
-
-/** 打字机参数：等 hero 入场动画结束再开始；每字符耗时 */
-const TYPE_DELAY = '0.45s'
+/** 打字机参数：每字符耗时（总时长由文本长度驱动） */
 const TYPE_SPEED = 0.13
+
+/** 对话轮次：驱动 hero 终端渲染（❓ user 提问 / ▲ tool 工具调用 / assistant 回答） */
+export type TerminalTurn =
+  | { role: 'user'; text: string }
+  | { role: 'tool'; call: string }
+  | {
+      role: 'assistant'
+      /** 回答行序列：文本或任意节点（如外链）；typewriter 仅对纯文本行生效 */
+      lines: { text: ReactNode; typewriter?: boolean }[]
+    }
 
 /**
  * 打字机文本（纯 CSS）：完整文本始终在 DOM 中（基础态 clip-path 不裁切），
  * animation 期间用 steps(字符数) 逐字符揭示；reduced-motion 下 animation 禁用
- * → 直接显示完整文本。--type-chars / --type-duration / --type-delay 由文本长度驱动。
+ * → 直接显示完整文本。--type-chars / --type-duration 由文本长度驱动；
+ * 延迟由所在轮次（--i）与演出节奏（--turn-gap）经 CSS calc 计算。
  */
 function TypewriterText({ text }: { text: string }) {
   return (
@@ -41,7 +44,6 @@ function TypewriterText({ text }: { text: string }) {
         {
           '--type-chars': text.length,
           '--type-duration': `${Math.max(text.length * TYPE_SPEED, 1.5)}s`,
-          '--type-delay': TYPE_DELAY,
         } as CSSProperties
       }
     >
@@ -51,38 +53,78 @@ function TypewriterText({ text }: { text: string }) {
   )
 }
 
-/** hero 终端窗口：窗口栏（装饰圆点 + 标题）+ 数据驱动命令流 */
-export default function HeroTerminal({ commands }: { commands: TerminalCommand[] }) {
-  return (
-    <div className="hero-terminal" role="group" aria-label="终端窗口">
-      <div className="hero-terminal-bar">
-        <span className="terminal-dot terminal-dot--red" aria-hidden="true" />
-        <span className="terminal-dot terminal-dot--yellow" aria-hidden="true" />
-        <span className="terminal-dot terminal-dot--green" aria-hidden="true" />
-        <span className="hero-terminal-title">hacxy@hacxy.cn: ~</span>
-      </div>
-      <div className="hero-terminal-body">
-        {commands.map(({ command, output, typewriter }) => (
-          <Fragment key={command}>
-            <div className="terminal-line">
-              <span className="terminal-prompt" aria-hidden="true">
-                $
-              </span>
-              <span>{command}</span>
-            </div>
-            <div className="terminal-line terminal-output">
-              {typewriter && typeof output === 'string' ? <TypewriterText text={output} /> : output}
-            </div>
-          </Fragment>
-        ))}
-        {/* 空闲提示符：行尾闪烁光标，终端「就绪」状态 */}
-        <div className="terminal-line">
-          <span className="terminal-prompt" aria-hidden="true">
-            $
+/** 单轮渲染：user（❓ 加粗）/ tool（▲ 缩进 mono 脉冲）/ assistant（回答行） */
+function TurnRow({ turn, index }: { turn: TerminalTurn; index: number }) {
+  // 轮次序号：CSS 演出编排参数（入场错开 / 打字机与脉冲延迟由 calc(var(--i) …) 计算）
+  const style = { '--i': index } as CSSProperties
+
+  if (turn.role === 'user') {
+    return (
+      <div className="hero-turn hero-turn--user" style={style}>
+        <span className="user-question">
+          <span className="turn-mark" aria-hidden="true">
+            ❓
           </span>
-          <span className="terminal-cursor" aria-hidden="true" />
+          {turn.text}
+        </span>
+      </div>
+    )
+  }
+
+  if (turn.role === 'tool') {
+    return (
+      <div className="hero-turn hero-turn--tool" style={style}>
+        <span className="tool-call">
+          <span aria-hidden="true">▲</span> tool: {turn.call}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="hero-turn hero-turn--answer" style={style}>
+      {turn.lines.map((line, i) => (
+        <div className="hero-line" key={i}>
+          {line.typewriter && typeof line.text === 'string' ? (
+            <TypewriterText text={line.text} />
+          ) : (
+            line.text
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** hero 终端（pi.dev 风格）：四角括号 + 会话轮次 + 底部 live caption */
+export default function HeroTerminal({ turns }: { turns: TerminalTurn[] }) {
+  return (
+    <div className="hero-terminal" role="group" aria-label="AI 会话演出">
+      {/* 四角括号装饰（┌ ┐ └ ┘，绝对定位不占文档流，不进可访问性树） */}
+      <span className="hero-terminal-corner hero-terminal-corner--tl" aria-hidden="true">
+        ┌
+      </span>
+      <span className="hero-terminal-corner hero-terminal-corner--tr" aria-hidden="true">
+        ┐
+      </span>
+      <div className="hero-terminal-scroll">
+        <div className="hero-terminal-body">
+          {turns.map((turn, i) => (
+            <TurnRow key={i} turn={turn} index={i} />
+          ))}
         </div>
       </div>
+      {/* 底部 caption：● live 红点 + 弱化 mono 文字（live 状态与演出说明） */}
+      <div className="hero-terminal-caption">
+        <span className="live-dot" aria-hidden="true" />
+        <span>live · AI 会话演出 · 自动播放一遍后停驻</span>
+      </div>
+      <span className="hero-terminal-corner hero-terminal-corner--bl" aria-hidden="true">
+        └
+      </span>
+      <span className="hero-terminal-corner hero-terminal-corner--br" aria-hidden="true">
+        ┘
+      </span>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -148,7 +148,7 @@ html.dark .bg-texture {
   pointer-events: none;
 }
 
-/* ===== hero 终端（issue #13）：大号站点名 + 数据驱动命令窗口 + 打字机 ===== */
+/* ===== hero 终端（issue #18）：pi.dev 风格 AI 会话演出 ===== */
 
 /* hero 区入场动画：克制（淡入 + 轻微上移 8px，纯 CSS） */
 .hero-enter {
@@ -165,31 +165,196 @@ html.dark .bg-texture {
   }
 }
 
-/* 终端窗口：窗口栏（装饰圆点 + 标题）+ mono 命令流；
-   overflow-x auto 保证长行在窗口内滚动，不撑破页面（375px 无横向滚动） */
+/* 终端框架（pi.dev 风格）：恒黑底白字，与页面 chrome 主题色解耦——亮暗模式均为
+   黑底白字（不随 .dark 切换）；四角括号装饰（┌┐└┘）；移除 mac 装饰圆点窗口栏。
+   overflow 移到内部 .hero-terminal-scroll（横向滚动不影响四角括号）；
+   --turn-gap / --turn-in 为演出编排参数：轮次入场按 --i * --turn-gap 依次错开 */
 .hero-terminal {
+  position: relative;
   margin-top: 1.25rem;
-  overflow-x: auto;
-  border: 1px solid var(--color-terminal-border);
-  border-radius: 0.75rem;
-  background: var(--color-terminal-bg);
+  border: 1px solid #2b2b2b;
+  background: #000;
+  color: #fff;
   font-family: var(--font-mono);
   font-size: 0.875rem;
   line-height: 1.75;
+  --turn-gap: 0.5s;
+  --turn-in: 0.45s;
 }
-.hero-terminal-bar {
+
+/* 四角括号：┌ ┐ └ ┘ 装饰在终端四角（重叠在边框线上，绝对定位不占文档流） */
+.hero-terminal-corner {
+  position: absolute;
+  z-index: 1;
+  font-size: 0.875rem;
+  line-height: 1;
+  color: #d9d9d9;
+  user-select: none;
+}
+.hero-terminal-corner--tl {
+  top: -1px;
+  left: -1px;
+}
+.hero-terminal-corner--tr {
+  top: -1px;
+  right: -1px;
+}
+.hero-terminal-corner--bl {
+  bottom: -1px;
+  left: -1px;
+}
+.hero-terminal-corner--br {
+  bottom: -1px;
+  right: -1px;
+}
+
+/* 横向滚动容器：长行（如 GitHub 链接）在小屏终端内滚动，不撑破页面 */
+.hero-terminal-scroll {
+  overflow-x: auto;
+}
+.hero-terminal-body {
+  padding: 1rem 1rem 0.75rem;
+}
+
+/* 对话轮次：逐段入场（淡入 + 轻微上移），按轮次序号 --i 依次错开；
+   自动播放一遍（iteration-count 1）后停在最终态，不循环 */
+.hero-turn {
+  animation: turn-in var(--turn-in) ease-out both;
+  animation-delay: calc(var(--i) * var(--turn-gap));
+}
+@keyframes turn-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* user 提问行：❓ 前缀 + 加粗（黑白下的第一视觉层级） */
+.user-question {
+  display: block;
+  font-weight: 700;
+}
+.turn-mark {
+  margin-right: 0.375rem;
+}
+
+/* tool 工具调用块：缩进 + mono + 灰阶脉冲（3 次后停在最终态，不循环）；
+   延迟等所在轮次入场后开始 */
+.hero-turn--tool .tool-call {
+  display: block;
+  margin-left: 1.5rem;
+  color: #d6d6d6;
+  animation: tool-pulse 0.8s ease-in-out 3 both;
+  animation-delay: calc(var(--i) * var(--turn-gap) + 0.35s);
+}
+@keyframes tool-pulse {
+  0%,
+  100% {
+    color: #d6d6d6;
+  }
+  50% {
+    color: #616161;
+  }
+}
+
+/* assistant 回答行：常规文本；多行之间留白 */
+.hero-line {
+  display: block;
+}
+.hero-line + .hero-line {
+  margin-top: 0.25rem;
+}
+
+/* 打字机文本（纯 CSS）：完整文本始终在 DOM（SEO / reduced-motion / 结束态直接可见），
+   动画用 clip-path 从右向左裁切 + steps(字符数) 逐字符揭示；
+   --type-chars / --type-duration 由组件按文本长度驱动；
+   延迟由所在轮次（--i）与演出节奏（--turn-gap）计算：所在轮次入场后开始打字 */
+.typewriter-text {
+  display: inline-block;
+  clip-path: inset(0 0 0 0);
+  animation-name: terminal-typing;
+  animation-duration: var(--type-duration, 1.5s);
+  animation-timing-function: steps(var(--type-chars, 14));
+  animation-delay: calc(var(--i, 0) * var(--turn-gap, 0.5s) + 0.3s);
+  animation-fill-mode: both;
+}
+@keyframes terminal-typing {
+  from {
+    clip-path: inset(0 100% 0 0);
+  }
+  to {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+/* 块状闪烁光标：打字机行尾（终端「正在输出」状态） */
+.terminal-cursor {
+  display: inline-block;
+  width: 0.55em;
+  height: 1.05em;
+  margin-left: 0.1em;
+  vertical-align: text-bottom;
+  background: #fff;
+  animation: terminal-blink 1.1s steps(1) infinite;
+}
+@keyframes terminal-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* 底部 caption：● live 红点 + 弱化 mono 文字（与正文以细线分隔）；
+   live 点脉冲有限次（4 次）后停在常亮，不循环 */
+.hero-terminal-caption {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.5rem 0.875rem;
-  border-bottom: 1px solid var(--color-terminal-border);
+  gap: 0.5rem;
+  padding: 0.5rem 1rem 0.75rem;
+  border-top: 1px solid #2b2b2b;
+  font-size: 0.75rem;
+  color: #8c8c8c;
 }
+.live-dot {
+  flex-shrink: 0;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: #ef4444;
+  animation: live-pulse 0.9s ease-in-out 4 both;
+  animation-delay: 0.2s;
+}
+@keyframes live-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+/* 终端内链接 hover：恒黑底终端自闭环（白底黑字反白），与页面 chrome 主题解耦 */
+.hero-terminal a:hover {
+  background-color: #fff;
+  color: #000;
+}
+
+/* 文章卡片（issue #14）：标题栏 ●●● 装饰圆点（亮色由浅到深、暗色由深到浅，
+   随主题切换）——仅文章卡片使用，hero 终端已移除 mac 装饰圆点窗口栏 */
 .terminal-dot {
   width: 0.625rem;
   height: 0.625rem;
   border-radius: 9999px;
 }
-/* 窗口装饰圆点：黑白灰阶（亮色由浅到深、暗色由深到浅），随主题切换 */
 .terminal-dot--red {
   background: #d9d9d9;
 }
@@ -207,70 +372,6 @@ html.dark .terminal-dot--yellow {
 }
 html.dark .terminal-dot--green {
   background: #6e6e6e;
-}
-.hero-terminal-title {
-  margin-left: 0.375rem;
-  font-size: 0.75rem;
-  color: var(--color-muted);
-}
-.hero-terminal-body {
-  padding: 0.875rem 1rem;
-}
-
-/* 命令行 / 输出行：$ 提示符灰（muted），命令默认前景色，输出统一终端输出色（灰阶令牌） */
-.terminal-line {
-  display: flex;
-  gap: 0.5rem;
-  overflow-wrap: anywhere;
-}
-.terminal-prompt {
-  color: var(--color-muted);
-  user-select: none;
-}
-.terminal-output {
-  color: var(--color-terminal);
-}
-
-/* 打字机文本（纯 CSS）：完整文本始终在 DOM（SEO / reduced-motion / 结束态直接可见），
-   动画用 clip-path 从右向左裁切 + steps(字符数) 逐字符揭示；
-   --type-chars / --type-duration / --type-delay 由组件按文本长度驱动 */
-.typewriter-text {
-  display: inline-block;
-  clip-path: inset(0 0 0 0);
-  animation-name: terminal-typing;
-  animation-duration: var(--type-duration, 1.5s);
-  animation-timing-function: steps(var(--type-chars, 14));
-  animation-delay: var(--type-delay, 0.45s);
-  animation-fill-mode: forwards;
-}
-@keyframes terminal-typing {
-  from {
-    clip-path: inset(0 100% 0 0);
-  }
-  to {
-    clip-path: inset(0 0 0 0);
-  }
-}
-
-/* 块状闪烁光标：打字机行尾 + 空闲提示符行尾 */
-.terminal-cursor {
-  display: inline-block;
-  width: 0.55em;
-  height: 1.05em;
-  margin-left: 0.1em;
-  vertical-align: text-bottom;
-  background: var(--color-terminal);
-  animation: terminal-blink 1.1s steps(1) infinite;
-}
-@keyframes terminal-blink {
-  0%,
-  49% {
-    opacity: 1;
-  }
-  50%,
-  100% {
-    opacity: 0;
-  }
 }
 
 /* ===== 文章卡片（issue #14）：终端窗口样式（标题栏 ●●● + 文件名 + 正文） ===== */
@@ -397,11 +498,14 @@ html.dark .terminal-dot--green {
   color: var(--color-accent);
 }
 
-/* 无障碍：prefers-reduced-motion 下禁用打字机 / 入场 / 光标闪烁动画，
-   直接显示完整文本（无动画报错；打字机为纯 CSS，无 JS 参与） */
+/* 无障碍：prefers-reduced-motion 下禁用打字机 / 入场 / 工具脉冲 / live 点 / 光标闪烁
+   动画，全文直接可见（无动画报错；演出编排为纯 CSS，无 JS 参与） */
 @media (prefers-reduced-motion: reduce) {
   .hero-enter,
+  .hero-turn,
   .typewriter-text,
+  .hero-turn--tool .tool-call,
+  .live-dot,
   .terminal-cursor,
   .post-card-enter {
     animation: none;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,14 @@
 import BackgroundDots from '../components/BackgroundDots.tsx'
-import HeroTerminal, { type TerminalCommand } from '../components/HeroTerminal.tsx'
+import HeroTerminal, { type TerminalTurn } from '../components/HeroTerminal.tsx'
 import PostCard from '../components/PostCard.tsx'
 import { posts } from '../content/index.ts'
 import { authorBio, githubUrl, siteName, tagline } from '../site.ts'
 
 /**
- * 首页：hero（大号站点名 h1 + 数据驱动终端窗口）+ 文章卡片列表（终端窗口样式，按日期倒序）。
- * 终端内容由「命令 + 输出 + 是否打字机」的数据结构驱动：文章数/标签数从内容清单自动
- * 计算（新增文章无需改代码），whoami 沿用站点信息，git clone 真实指向 GitHub。
+ * 首页：hero（大号站点名 h1 + pi.dev 风格 AI 会话演出终端）+ 文章卡片列表。
+ * 终端内容由「对话轮次」数据结构驱动（user 提问 / tool 工具调用 / assistant 回答，
+ * issue #18）：文章数/标签数从内容清单自动计算（新增文章无需改代码），
+ * 简介/tagline 沿用站点信息，GitHub 外链真实指向仓库。
  * 文章区为终端样式卡片（标题栏 ●●● + slug 文件名 + 标题/摘要/日期/标签徽章），
  * 内容由内容清单驱动，整卡可点击进入 /posts/:slug（issue #14）。
  */
@@ -16,23 +17,27 @@ export default function Home() {
   const postCount = posts.length
   const tagCount = new Set(posts.flatMap((post) => post.tags)).size
 
-  const commands: TerminalCommand[] = [
-    { command: 'whoami', output: `hacxy · ${authorBio}` },
-    { command: 'cat tagline.txt', output: tagline, typewriter: true },
-    { command: 'ls posts', output: `${postCount} 篇文章 · ${tagCount} 个标签` },
-    { command: 'npm run build', output: '✓ 构建成功 · 0 错误，产物已就绪' },
+  // 三轮问答剧本（issue #18）：你是谁 / 这个站有什么 / 怎么联系
+  const turns: TerminalTurn[] = [
+    { role: 'user', text: '你是谁' },
+    { role: 'tool', call: 'read about.md' },
+    { role: 'assistant', lines: [{ text: authorBio }, { text: tagline, typewriter: true }] },
+    { role: 'user', text: '这个站有什么' },
+    { role: 'tool', call: 'ls posts' },
+    { role: 'assistant', lines: [{ text: `${postCount} 篇文章 · ${tagCount} 个标签` }] },
+    { role: 'user', text: '怎么联系' },
+    { role: 'tool', call: 'open github.com/hacxy' },
     {
-      command: 'git clone',
-      output: (
-        <a
-          href={githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-terminal underline underline-offset-2"
-        >
-          {githubUrl}
-        </a>
-      ),
+      role: 'assistant',
+      lines: [
+        {
+          text: (
+            <a href={githubUrl} target="_blank" rel="noopener noreferrer">
+              {githubUrl}
+            </a>
+          ),
+        },
+      ],
     },
   ]
 
@@ -43,7 +48,7 @@ export default function Home() {
       {/* hero 区：克制的入场动画（淡入 + 轻微上移，纯 CSS，reduced-motion 禁用） */}
       <section className="hero-enter">
         <h1 className="font-mono text-4xl font-bold tracking-tight">{siteName}</h1>
-        <HeroTerminal commands={commands} />
+        <HeroTerminal turns={turns} />
       </section>
       <ul className="post-card-list">
         {posts.map((post) => (

--- a/src/site.ts
+++ b/src/site.ts
@@ -1,7 +1,7 @@
 /** 站点基础信息 */
 export const siteName = 'Hacxy'
 export const tagline = '了解真相，才能获得真正的自由'
-/** 作者简介（hero 终端 whoami 输出，单一来源） */
+/** 作者简介（hero 终端「你是谁」助手回答，单一来源） */
 export const authorBio = '前端工程师 · 关注 Web 生态与工程化'
 /** 站点绝对地址（canonical / OG / sitemap / RSS 共用） */
 export const siteUrl = 'https://hacxy.cn'

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -21,34 +21,43 @@ function normalizeDate(value: string | Date | undefined): string {
   return typeof value === 'string' ? value : value.toISOString().slice(0, 10)
 }
 
-test('hero: big h1 site name + terminal window with all command outputs', async ({ page }) => {
+test('hero: big h1 site name + AI agent conversation (three Q&A rounds)', async ({ page }) => {
   await page.goto('/')
 
   // 大号站点名作为 h1（既有 E2E 对 h1 的断言保留）
   const heading = page.getByRole('heading', { level: 1, name: 'Hacxy' })
   await expect(heading).toBeVisible()
 
-  // 终端窗口可见
+  // pi.dev 风格会话演出终端可见
   const terminal = page.locator('.hero-terminal')
   await expect(terminal).toBeVisible()
 
-  // 每条命令带 $ 提示符：whoami / cat tagline.txt / ls posts / npm run build / git clone
-  // （5 条命令 + 1 个空闲提示符）
-  await expect(terminal.locator('.terminal-prompt')).toHaveCount(6)
-  for (const command of ['whoami', 'cat tagline.txt', 'ls posts', 'npm run build', 'git clone']) {
-    await expect(terminal.getByText(command)).toBeVisible()
+  // 三轮问答的 ❓ user 提问行（加粗，黑白下的第一视觉层级）
+  for (const question of ['你是谁', '这个站有什么', '怎么联系']) {
+    const q = terminal.locator('.user-question').filter({ hasText: question })
+    await expect(q).toBeVisible()
+    expect(await q.evaluate((el) => getComputedStyle(el).fontWeight)).toBe('700')
   }
 
-  // whoami 输出：自我介绍（沿用站点信息）
+  // ▲ tool 工具调用块（缩进 + mono + 灰阶脉冲）：read about.md / ls posts / open github.com/hacxy
+  for (const call of ['read about.md', 'ls posts', 'open github.com/hacxy']) {
+    const tool = terminal.locator('.tool-call').filter({ hasText: call })
+    await expect(tool).toBeVisible()
+    expect(await tool.evaluate((el) => getComputedStyle(el).fontFamily)).toContain('JetBrains Mono')
+  }
+
+  // assistant 回答：简介 + tagline（打字机结束态全文可见，不做时序断言）
   await expect(terminal.getByText(/前端工程师/)).toBeVisible()
-  // tagline 全文最终可见（打字机结束态，不做时序断言）
   await expect(terminal.getByText('了解真相，才能获得真正的自由')).toBeVisible()
-  // npm run build 成功输出
-  await expect(terminal.getByText(/构建成功/)).toBeVisible()
-  // git clone：真实指向 GitHub 的链接
-  const cloneLink = terminal.getByRole('link', { name: 'https://github.com/hacxy' })
-  await expect(cloneLink).toBeVisible()
-  await expect(cloneLink).toHaveAttribute('href', 'https://github.com/hacxy')
+
+  // 怎么联系 → GitHub 外链：下划线 + 加粗（黑白下区分，与页面 chrome 一致）
+  const githubLink = terminal.getByRole('link', { name: 'https://github.com/hacxy' })
+  await expect(githubLink).toBeVisible()
+  await expect(githubLink).toHaveAttribute('href', 'https://github.com/hacxy')
+  expect(await githubLink.evaluate((el) => getComputedStyle(el).textDecorationLine)).toContain(
+    'underline',
+  )
+  expect(await githubLink.evaluate((el) => getComputedStyle(el).fontWeight)).toBe('700')
 })
 
 test('hero terminal: ls posts counts match the content manifest', async ({ page }) => {
@@ -69,24 +78,119 @@ test('hero terminal: ls posts counts match the content manifest', async ({ page 
   await expect(terminal.getByText(new RegExp(`${tagCount} 个标签`))).toBeVisible()
 })
 
-test('prerendered HTML contains hero terminal text and site name (SEO no regression)', async ({
-  request,
+test('hero terminal: always black background with white text in light and dark themes', async ({
+  page,
 }) => {
-  const html = await (await request.get('/')).text()
+  await page.goto('/')
+  const html = page.locator('html')
+  const terminal = page.locator('.hero-terminal')
 
-  // 站点名 h1 + tagline 全文 + 各命令/输出都在预渲染源码中（爬虫不执行 JS 即可见）
-  expect(html).toContain('Hacxy')
-  expect(html).toContain('了解真相，才能获得真正的自由')
-  expect(html).toContain('whoami')
-  expect(html).toContain('cat tagline.txt')
-  expect(html).toContain('ls posts')
-  expect(html).toContain('npm run build')
-  expect(html).toContain('git clone')
-  expect(html).toContain('https://github.com/hacxy')
-  expect(html).toContain('前端工程师')
+  // 归一化到亮色：恒黑底白字（与页面 chrome 主题色解耦）
+  if (((await html.getAttribute('class')) ?? '').includes('dark')) {
+    await page.getByRole('button', { name: '切换暗色模式' }).click()
+  }
+  await expect(terminal).toHaveCSS('background-color', 'rgb(0, 0, 0)')
+  await expect(terminal).toHaveCSS('color', 'rgb(255, 255, 255)')
+
+  // 暗色模式同样恒黑底白字（不随主题反色）
+  await page.getByRole('button', { name: '切换暗色模式' }).click()
+  await expect(terminal).toHaveCSS('background-color', 'rgb(0, 0, 0)')
+  await expect(terminal).toHaveCSS('color', 'rgb(255, 255, 255)')
 })
 
-test('hero terminal: reduced-motion skips typewriter, full text visible, no animation errors', async ({
+test('hero terminal: four corner brackets + bottom live caption (red dot, weak mono text)', async ({
+  page,
+}) => {
+  await page.goto('/')
+  const terminal = page.locator('.hero-terminal')
+
+  // 四角括号：┌ ┐ └ ┘ 四个角装饰
+  const corners = terminal.locator('.hero-terminal-corner')
+  await expect(corners).toHaveCount(4)
+  expect((await corners.allTextContents()).sort()).toEqual(['┌', '┐', '└', '┘'].sort())
+
+  // 底部 caption：● live 红点 + 弱化 mono 文字（与正文以细线分隔）
+  const caption = terminal.locator('.hero-terminal-caption')
+  await expect(caption).toBeVisible()
+  await expect(caption.getByText(/live/)).toBeVisible()
+  expect(await caption.evaluate((el) => getComputedStyle(el).fontFamily)).toContain(
+    'JetBrains Mono',
+  )
+
+  // live 红点：红色系（灰阶之外的唯一彩色系，live 状态指示）
+  const dot = caption.locator('.live-dot')
+  await expect(dot).toBeVisible()
+  expect(await dot.evaluate((el) => getComputedStyle(el).backgroundColor)).toBe('rgb(239, 68, 68)')
+
+  // 无 mac 装饰圆点窗口栏（issue #18 移除；文章卡片的 ●●● 标题栏不受影响）
+  await expect(terminal.locator('.hero-terminal-bar')).toHaveCount(0)
+})
+
+test('prerendered HTML contains the full conversation text (SEO no regression)', async ({
+  request,
+}) => {
+  // 站点名 h1 + 三轮问答全文（user 提问 / tool 调用 / assistant 回答 / caption）
+  // 都在预渲染源码中（爬虫不执行 JS 即可读）。注：React SSR 会在混合静态文本与
+  // 表达式的节点间插入 <!-- --> 注释（文本本身连续），故先剥离再断言全文
+  const html = (await (await request.get('/')).text()).replaceAll('<!-- -->', '')
+
+  expect(html).toContain('Hacxy')
+  expect(html).toContain('你是谁')
+  expect(html).toContain('这个站有什么')
+  expect(html).toContain('怎么联系')
+  expect(html).toContain('tool: read about.md')
+  expect(html).toContain('tool: ls posts')
+  expect(html).toContain('tool: open github.com/hacxy')
+  expect(html).toContain('前端工程师')
+  expect(html).toContain('了解真相，才能获得真正的自由')
+  expect(html).toContain('https://github.com/hacxy')
+  expect(html).toContain('live')
+})
+
+test('hero terminal: CSS show plays once and stops at the final state (no loop)', async ({
+  page,
+}) => {
+  await page.goto('/')
+  const terminal = page.locator('.hero-terminal')
+
+  // 演出动画均为有限次数（不循环）：逐段入场 1 次、打字机 1 次、工具脉冲 3 次、live 点脉冲 4 次
+  expect(
+    await terminal
+      .locator('.hero-turn')
+      .first()
+      .evaluate((el) => getComputedStyle(el).animationIterationCount),
+  ).toBe('1')
+  expect(
+    await terminal
+      .locator('.typewriter-text')
+      .evaluate((el) => getComputedStyle(el).animationIterationCount),
+  ).toBe('1')
+  expect(
+    await terminal
+      .locator('.tool-call')
+      .first()
+      .evaluate((el) => getComputedStyle(el).animationIterationCount),
+  ).toBe('3')
+  expect(
+    await terminal
+      .locator('.live-dot')
+      .evaluate((el) => getComputedStyle(el).animationIterationCount),
+  ).toBe('4')
+
+  // 等演出播完（9 轮 × 0.5s 错开 + 入场时长 + 打字机/脉冲尾段），停在最终态：
+  // 最后一轮完全可见（opacity 1），tagline 全文揭示
+  await expect
+    .poll(() =>
+      terminal
+        .locator('.hero-turn')
+        .last()
+        .evaluate((el) => getComputedStyle(el).opacity),
+    )
+    .toBe('1')
+  await expect(terminal.getByText('了解真相，才能获得真正的自由')).toBeVisible()
+})
+
+test('hero terminal: reduced-motion skips all animations, full text visible, no errors', async ({
   page,
 }) => {
   const pageErrors: string[] = []
@@ -95,11 +199,30 @@ test('hero terminal: reduced-motion skips typewriter, full text visible, no anim
   await page.emulateMedia({ reducedMotion: 'reduce' })
   await page.goto('/')
 
-  // 完整 tagline 直接显示（无需等待打字机）
-  const tagline = page.getByText('了解真相，才能获得真正的自由')
-  await expect(tagline).toBeVisible()
-  // 打字机与 hero 入场动画都被禁用（纯 CSS 动画，reduce 下 animation: none）
-  expect(await tagline.evaluate((el) => getComputedStyle(el).animationName)).toBe('none')
+  // 全文直接可见（无需等待动画）：三轮提问 + tool 调用 + tagline 全文
+  for (const text of ['你是谁', '这个站有什么', '怎么联系', '了解真相，才能获得真正的自由']) {
+    await expect(page.getByText(text).first()).toBeVisible()
+  }
+
+  // 逐段入场 / 打字机 / 工具脉冲 / live 点脉冲 / hero 入场全部禁用（animation: none）
+  expect(
+    await page
+      .locator('.hero-turn')
+      .first()
+      .evaluate((el) => getComputedStyle(el).animationName),
+  ).toBe('none')
+  expect(
+    await page.locator('.typewriter-text').evaluate((el) => getComputedStyle(el).animationName),
+  ).toBe('none')
+  expect(
+    await page
+      .locator('.tool-call')
+      .first()
+      .evaluate((el) => getComputedStyle(el).animationName),
+  ).toBe('none')
+  expect(await page.locator('.live-dot').evaluate((el) => getComputedStyle(el).animationName)).toBe(
+    'none',
+  )
   expect(
     await page.locator('.hero-enter').evaluate((el) => getComputedStyle(el).animationName),
   ).toBe('none')
@@ -838,7 +961,7 @@ test('nav icon links are keyboard focusable', async ({ page }) => {
   await expect(page.locator('canvas.bg-dots')).toHaveCount(1)
 
   // Tab 顺序：文章 → 关于 → 主题切换 → GitHub → RSS（键盘无障碍验收，PRD 用户故事 33）
-  // 限定 navigation：避免与 hero 终端内 git clone 链接（名字含 github）歧义（strict mode）
+  // 限定 navigation：避免与 hero 终端内 GitHub 外链（名字含 github）歧义（strict mode）
   const nav = page.getByRole('navigation')
   for (let i = 0; i < 4; i++) await page.keyboard.press('Tab')
   await expect(nav.getByRole('link', { name: 'GitHub' })).toBeFocused()


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

将首页 hero 终端重构为 pi.dev 风格 AI agent 会话演出：数据模型改为对话轮次（user/tool/assistant）、恒黑底白字四角括号框架 + live caption（移除 mac 圆点栏）、三轮问答剧本（你是谁/这个站有什么/怎么联系）、纯 CSS 一次性演出编排（逐段入场/打字机/工具灰阶脉冲）且 reduced-motion 全文直接可见，E2E 断言全部更新并通过（48/48），已提交 commit 4cce494（Ralph: issue-18）。

Closes #18