### PR TITLE
fix: issue #24 hero 终端 caption 精简为「● live」+ live 点持续闪烁

### DIFF
--- a/src/components/HeroTerminal.tsx
+++ b/src/components/HeroTerminal.tsx
@@ -11,10 +11,12 @@ import { type CSSProperties, type ReactNode } from 'react'
  *   解耦）、四角括号装饰（┌┐└┘）、底部 caption（● live 红点 + 弱化 mono 文字）；
  *   移除 mac 装饰圆点窗口栏（文章卡片行不沿用窗口栏形态，见 PostRow）
  * - 演出编排为纯 CSS：逐段入场（轮次按 --i * --turn-gap 依次错开）、tagline 打字机
- *   （clip-path + steps）、tool 块灰阶脉冲、live 点脉冲；全部自动播放一遍后停在
- *   最终态、不循环；SSR 与客户端首帧都渲染完整对话文本（预渲染 HTML 含全文、
- *   SEO 不回归、无 hydration mismatch），prefers-reduced-motion 时 media query
- *   整体禁用动画、全文直接可见，无 JS 报错
+ *   （clip-path + steps）、tool 块灰阶脉冲；自动播放一遍后停在最终态、不循环；
+ *   live 红点除外——caption 精简为「● live」（去掉演出说明），红点以软脉冲无限
+ *   循环（0.9s，opacity 1↔0.35，红色不变）；SSR 与客户端首帧都渲染完整对话文本
+ *   （预渲染 HTML 含全文、SEO 不回归、无 hydration mismatch），
+ *   prefers-reduced-motion 时 media query 整体禁用动画（含 live 点静止）、
+ *   全文直接可见，无 JS 报错
  */
 
 /** 打字机参数：每字符耗时（总时长由文本长度驱动） */
@@ -114,10 +116,10 @@ export default function HeroTerminal({ turns }: { turns: TerminalTurn[] }) {
           ))}
         </div>
       </div>
-      {/* 底部 caption：● live 红点 + 弱化 mono 文字（live 状态与演出说明） */}
+      {/* 底部 caption：● live 红点 + 弱化 mono 文字（可见文本精简为「live」） */}
       <div className="hero-terminal-caption">
         <span className="live-dot" aria-hidden="true" />
-        <span>live · AI 会话演出 · 自动播放一遍后停驻</span>
+        <span>live</span>
       </div>
       <span className="hero-terminal-corner hero-terminal-corner--bl" aria-hidden="true">
         └

--- a/src/index.css
+++ b/src/index.css
@@ -314,7 +314,7 @@ html.dark .bg-texture {
 }
 
 /* 底部 caption：● live 红点 + 弱化 mono 文字（与正文以细线分隔）；
-   live 点脉冲有限次（4 次）后停在常亮，不循环 */
+   可见文本精简为「live」——去掉演出说明（issue #24） */
 .hero-terminal-caption {
   display: flex;
   align-items: center;
@@ -330,8 +330,8 @@ html.dark .bg-texture {
   height: 0.5rem;
   border-radius: 9999px;
   background: #ef4444;
-  animation: live-pulse 0.9s ease-in-out 4 both;
-  animation-delay: 0.2s;
+  /* 软脉冲无限循环（0.9s，opacity 1↔0.35，红色不变）：live 状态持续闪烁指示 */
+  animation: live-pulse 0.9s ease-in-out infinite;
 }
 @keyframes live-pulse {
   0%,
@@ -472,7 +472,8 @@ html.dark .terminal-dot--green {
 }
 
 /* 无障碍：prefers-reduced-motion 下禁用打字机 / 入场 / 工具脉冲 / live 点 / 光标闪烁
-   动画，全文直接可见（无动画报错；演出编排为纯 CSS，无 JS 参与） */
+   动画，全文直接可见（live 红点静止、演出全文直接可见；无动画报错；演出编排为纯
+   CSS，无 JS 参与） */
 @media (prefers-reduced-motion: reduce) {
   .hero-enter,
   .hero-turn,

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -109,10 +109,13 @@ test('hero terminal: four corner brackets + bottom live caption (red dot, weak m
   await expect(corners).toHaveCount(4)
   expect((await corners.allTextContents()).sort()).toEqual(['┌', '┐', '└', '┘'].sort())
 
-  // 底部 caption：● live 红点 + 弱化 mono 文字（与正文以细线分隔）
+  // 底部 caption：● live 红点 + 弱化 mono 文字（与正文以细线分隔）；
+  // 可见文本精简为「live」（去掉演出说明「AI 会话演出 · 自动播放一遍后停驻」）
   const caption = terminal.locator('.hero-terminal-caption')
   await expect(caption).toBeVisible()
-  await expect(caption.getByText(/live/)).toBeVisible()
+  await expect(caption).toHaveText('live', { useInnerText: true })
+  await expect(caption.getByText('AI 会话演出')).toHaveCount(0)
+  await expect(caption.getByText('自动播放一遍后停驻')).toHaveCount(0)
   expect(await caption.evaluate((el) => getComputedStyle(el).fontFamily)).toContain(
     'JetBrains Mono',
   )
@@ -147,13 +150,14 @@ test('prerendered HTML contains the full conversation text (SEO no regression)',
   expect(html).toContain('live')
 })
 
-test('hero terminal: CSS show plays once and stops at the final state (no loop)', async ({
+test('hero terminal: CSS show plays once and stops; live dot pulses infinitely', async ({
   page,
 }) => {
   await page.goto('/')
   const terminal = page.locator('.hero-terminal')
 
-  // 演出动画均为有限次数（不循环）：逐段入场 1 次、打字机 1 次、工具脉冲 3 次、live 点脉冲 4 次
+  // 演出动画均播放一遍后停驻：逐段入场 1 次、打字机 1 次、工具脉冲 3 次（不循环）；
+  // 仅 live 红点无限循环（软脉冲，0.9s）——持续闪烁的 live 状态指示
   expect(
     await terminal
       .locator('.hero-turn')
@@ -175,7 +179,11 @@ test('hero terminal: CSS show plays once and stops at the final state (no loop)'
     await terminal
       .locator('.live-dot')
       .evaluate((el) => getComputedStyle(el).animationIterationCount),
-  ).toBe('4')
+  ).toBe('infinite')
+  // live 点软脉冲周期 0.9s（opacity 1↔0.35）
+  expect(
+    await terminal.locator('.live-dot').evaluate((el) => getComputedStyle(el).animationDuration),
+  ).toBe('0.9s')
 
   // 等演出播完（9 轮 × 0.5s 错开 + 入场时长 + 打字机/脉冲尾段），停在最终态：
   // 最后一轮完全可见（opacity 1），tagline 全文揭示


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

完成 issue #24：hero 终端 caption 精简为「● live」并去掉演出说明，live 红点改为 0.9s 无限软脉冲（opacity 1↔0.35），reduced-motion 下静止、SSR 全文不变；e2e 断言同步更新（live 点迭代 4 → infinite + 0.9s 周期 + caption 精确文本），typecheck/lint/22 单测/49 e2e 全绿，已提交 bedeebc（Ralph: issue-24）。

Closes #24