### PR TITLE
fix: issue #25 文章行 hover/focus 交互：终端提示符 + 标题下划线

### DIFF
--- a/src/components/PostRow.tsx
+++ b/src/components/PostRow.tsx
@@ -10,9 +10,11 @@ import { Link } from 'react-router'
  *
  * 设计决策：
  * - 整行为单个 <Link>（无嵌套链接）：日期/标题/标签任意位置点击均进入
- *   /posts/:slug；键盘可达（真实链接 + :focus-visible 反白反馈）
- * - hover / focus-visible 反白：复用全站 accent 令牌（亮色黑底白字、
- *   暗色白底黑字反色），与页面 chrome 的链接反馈机制一致
+ *   /posts/:slug；键盘可达（真实链接 + :focus-visible 反馈）
+ * - hover / focus-visible 反馈（issue #25）：行首预留沟槽中淡入 accent 色「>」
+ *   终端提示符（槽始终占位 → 内容零位移），标题变 accent 色 + 下划线（字重
+ *   保持 400），日期/标签保持 muted；整行背景不再黑白反转（全站链接/导航/
+ *   页脚反白机制为文章行特例豁免，其余链接不受影响）
  * - 标签仅展示、不跳转（当前无标签路由）：渲染为 #tag 纯文本 span，非链接
  * - 行内容完全由内容清单驱动（title / date / tags），新增文章自动上首页，
  *   内容管线零改动
@@ -26,6 +28,11 @@ export default function PostRow({ post, index }: { post: Post; index: number }) 
   return (
     <li className="post-row-enter" style={style}>
       <Link to={`/posts/${post.slug}`} className="post-row">
+        {/* 行首终端提示符：装饰性（aria-hidden，不进可访问名），hover/键盘焦点时淡入；
+            槽始终占位 → 内容零位移（issue #25） */}
+        <span className="post-row-prompt" aria-hidden="true">
+          &gt;
+        </span>
         <time dateTime={post.date} className="post-row-date">
           {post.date}
         </time>

--- a/src/index.css
+++ b/src/index.css
@@ -415,26 +415,44 @@ html.dark .terminal-dot--green {
 }
 
 /* 整行为单个链接：mono 日期 + 标题 + #标签（终端 ls 输出行形态）；
-   hover / 键盘 focus-visible 反白反馈（复用全站 accent 令牌：亮色黑底白字、
-   暗色白底黑字反色）；行内不渲染摘要（内容管线保留 description，文章页/SEO 继续使用） */
+   hover / 键盘 focus-visible 反馈（issue #25）：行首沟槽淡入「>」终端提示符 +
+   标题 accent 色 + 下划线（字重保持 400），日期/标签保持 muted，
+   整行背景不再黑白反转（全站链接反白机制为文章行特例豁免）；
+   行内不渲染摘要（内容管线保留 description，文章页/SEO 继续使用） */
 .post-row {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
   gap: 0.25rem 0.875rem;
   padding: 0.5rem 0.375rem;
-  border-radius: 0.25rem;
   font-weight: 400;
   text-decoration: none;
   overflow-wrap: anywhere;
-  transition:
-    background-color 0.15s ease,
-    color 0.15s ease;
 }
+
+/* 行首提示符「>」：槽始终占位（预留沟槽 → 内容零位移），hover/focus 时淡入；
+   负 margin 抵消容器 column-gap（与 .post-row 的 gap 0.875rem 保持同步），
+   「>」与日期间距由槽内空隙决定（≈0.55rem，终端单空格风格） */
+.post-row-prompt {
+  flex: 0 0 1rem;
+  margin-right: -0.875rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--color-accent);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.post-row:hover .post-row-prompt,
+.post-row:focus-visible .post-row-prompt {
+  opacity: 1;
+}
+
+/* hover/focus 时整行豁免全站 a:hover 反白（背景保持透明、文字保持继承色），
+   与页面 chrome 链接的反白机制解耦 */
 .post-row:hover,
 .post-row:focus-visible {
-  background-color: var(--color-accent);
-  color: var(--color-accent-contrast);
+  background-color: transparent;
+  color: inherit;
 }
 
 /* 日期：mono、弱化（亮色灰 / 暗色浅灰随主题）；YYYY-MM-DD 等宽自然对齐 */
@@ -444,11 +462,19 @@ html.dark .terminal-dot--green {
   color: var(--color-muted);
 }
 
-/* 标题：常规字重（终端输出文本层级），占满剩余宽度、可换行不撑破小屏 */
+/* 标题：常规字重（终端输出文本层级），占满剩余宽度、可换行不撑破小屏；
+   hover/focus：accent 色 + 下划线（与全站链接同风格 text-underline-offset），
+   字重保持 400 不变 */
 .post-row-title {
   flex: 1 1 auto;
   font-size: 1rem;
   line-height: 1.5;
+}
+.post-row:hover .post-row-title,
+.post-row:focus-visible .post-row-title {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 /* #标签：仅展示、不跳转（当前无标签路由）；mono 弱化，与日期同一层级 */
@@ -463,14 +489,6 @@ html.dark .terminal-dot--green {
   color: var(--color-muted);
 }
 
-/* 反白反馈时日期/标签随行文字一起反色（muted 覆盖为 inherit） */
-.post-row:hover .post-row-date,
-.post-row:focus-visible .post-row-date,
-.post-row:hover .post-row-tag,
-.post-row:focus-visible .post-row-tag {
-  color: inherit;
-}
-
 /* 无障碍：prefers-reduced-motion 下禁用打字机 / 入场 / 工具脉冲 / live 点 / 光标闪烁
    动画，全文直接可见（无动画报错；演出编排为纯 CSS，无 JS 参与） */
 @media (prefers-reduced-motion: reduce) {
@@ -483,8 +501,8 @@ html.dark .terminal-dot--green {
   .post-row-enter {
     animation: none;
   }
-  /* 行 hover 反白的过渡同为动画：reduce 下禁用（反白本身保留，瞬时切换） */
-  .post-row {
+  /* 行提示符淡入过渡同为动画：reduce 下禁用（提示符/标题反馈本身保留，瞬时切换） */
+  .post-row-prompt {
     transition: none;
   }
 }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -297,26 +297,46 @@ test('clicking a post row opens the post page (whole row is clickable)', async (
   await expect(page.getByRole('heading', { name: '你好，世界' })).toBeVisible()
 })
 
-test('post row hover feedback: inverted background (反白) in light and dark themes', async ({
+test('post row hover feedback: terminal prompt fades in + title underline, no background inversion (light & dark)', async ({
   page,
 }) => {
   await page.goto('/')
   const row = page.locator('.post-row').first()
+  const prompt = row.locator('.post-row-prompt')
+  const title = row.locator('.post-row-title')
 
-  // 归一化亮色：hover 反白 = 黑底白字（与全站链接同一 accent 令牌机制）
+  // 归一化亮色（初始主题由环境决定，先切到已知状态）
   const html = page.locator('html')
   if (((await html.getAttribute('class')) ?? '').includes('dark')) {
     await page.getByRole('button', { name: '切换暗色模式' }).click()
   }
-  await row.hover()
-  await expect(row).toHaveCSS('background-color', 'rgb(26, 26, 26)')
-  await expect(row).toHaveCSS('color', 'rgb(255, 255, 255)')
 
-  // 暗色模式：hover 反白 = 白底黑字（黑底白字反色）
+  // 默认态：提示符隐藏（opacity 0）、标题无下划线
+  await expect(prompt).toHaveText('>')
+  await expect(prompt).toHaveCSS('opacity', '0')
+  expect(await title.evaluate((el) => getComputedStyle(el).textDecorationLine)).not.toContain(
+    'underline',
+  )
+
+  // hover 行：行首「>」提示符淡入（opacity 1）、标题 accent 色 + 下划线、
+  // 无背景反白、日期/标签保持 muted 灰
+  await row.hover()
+  await expect(prompt).toHaveCSS('opacity', '1')
+  await expect(title).toHaveCSS('color', 'rgb(26, 26, 26)') // accent = 近黑（亮色）
+  await expect(title).toHaveCSS('text-decoration-line', 'underline')
+  await expect(row).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)') // 无黑白反转
+  await expect(row.locator('.post-row-date')).toHaveCSS('color', 'rgb(102, 102, 102)')
+  await expect(row.locator('.post-row-tag').first()).toHaveCSS('color', 'rgb(102, 102, 102)')
+
+  // 暗色模式：同一反馈（accent = 近白、muted = 浅灰，背景同样不反白）
   await page.getByRole('button', { name: '切换暗色模式' }).click()
   await row.hover()
-  await expect(row).toHaveCSS('background-color', 'rgb(230, 230, 230)')
-  await expect(row).toHaveCSS('color', 'rgb(0, 0, 0)')
+  await expect(prompt).toHaveCSS('opacity', '1')
+  await expect(title).toHaveCSS('color', 'rgb(230, 230, 230)')
+  await expect(title).toHaveCSS('text-decoration-line', 'underline')
+  await expect(row).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+  await expect(row.locator('.post-row-date')).toHaveCSS('color', 'rgb(158, 158, 158)')
+  await expect(row.locator('.post-row-tag').first()).toHaveCSS('color', 'rgb(158, 158, 158)')
 })
 
 test('post list entrance: last act of the stream, staggered after the conversation ends', async ({
@@ -353,6 +373,8 @@ test('post list entrance: last act of the stream, staggered after the conversati
   await page.goto('/')
   await expect(page.getByText('你好，世界')).toBeVisible()
   await expect(page.locator('.post-row-enter').first()).toHaveCSS('animation-name', 'none')
+  // prefers-reduced-motion：行反馈过渡禁用（提示符瞬时切换，无动画）
+  await expect(page.locator('.post-row-prompt').first()).toHaveCSS('transition-duration', '0s')
   expect(pageErrors).toHaveLength(0)
 })
 
@@ -375,8 +397,13 @@ test('post rows are keyboard reachable: Tab focus, visible focus style, Enter op
   const firstRowLink = page.locator('.post-row').first()
   await expect(firstRowLink).toBeFocused()
 
-  // 键盘焦点有可见反白反馈（与 hover 同一机制）
-  await expect(firstRowLink).toHaveCSS('background-color', 'rgb(26, 26, 26)')
+  // 键盘焦点反馈（与 hover 同一机制）：行首「>」提示符淡入 + 标题下划线，背景不反白
+  await expect(firstRowLink.locator('.post-row-prompt')).toHaveCSS('opacity', '1')
+  await expect(firstRowLink.locator('.post-row-title')).toHaveCSS(
+    'text-decoration-line',
+    'underline',
+  )
+  await expect(firstRowLink).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
 
   // Enter 打开文章
   await page.keyboard.press('Enter')


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

Issue #25 完成：文章行 hover/:focus-visible 改为行首预留沟槽淡入 accent 色「>」提示符（内容零位移）+ 标题 accent 下划线（字重 400），日期/标签保持 muted、背景不再反白（全站链接反白机制不受影响），prefers-reduced-motion 下过渡禁用；e2e 已重写原反白断言为提示符+下划线，typecheck/lint/单测/49 个 e2e 全绿，已提交 bdd0b06（Ralph: issue-25）。

Closes #25