### PR TITLE
fix: issue #26 高分屏根字号阶梯缩放（≥1920px → 18px，≥2560px → 20px）

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -114,6 +114,22 @@ html.dark {
   }
 }
 
+/* 高分屏根字号阶梯缩放（issue #26）：视口 ≥1920px 根字号升至 18px（1.125rem），
+   ≥2560px 升至 20px（1.25rem）——正文/终端/文章行/导航全部随根字号等比放大，
+   内容列宽随 rem 自然变宽（max-w-2xl = 42rem：672→756→840px，中文行宽仍在舒适区）；
+   1920px 以下保持浏览器默认 16px 基准。纯 CSS 媒体查询：无 JS/组件改动、
+   SSR 与 hydration 不受影响（html 基础样式在 @layer base，此处非层内规则优先）。 */
+@media (min-width: 1920px) {
+  html {
+    font-size: 18px;
+  }
+}
+@media (min-width: 2560px) {
+  html {
+    font-size: 20px;
+  }
+}
+
 /*
  * Shiki 双主题代码高亮：亮色为内联 style，html.dark 时切换 --shiki-dark 变量。
  * （.dark 由防闪烁脚本在首帧前设置，代码块随页面主题即时切换，无闪烁。）

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1020,6 +1020,55 @@ test('nav icon links are keyboard focusable', async ({ page }) => {
   await expect(nav.getByRole('link', { name: 'RSS' })).toBeFocused()
 })
 
+test('high-DPI root font-size scaling: 1920px → 18px, 2560px → 20px, below 1920px stays 16px', async ({
+  browser,
+}) => {
+  // 高分屏根字号阶梯（issue #26）：纯 CSS 媒体查询（min-width），rem 单位全部等比放大。
+  // 期望值表：视口宽 → 根字号 → hero 终端字号（0.875rem）→ 文章行标题字号（1rem）→
+  // 内容列宽（max-w-2xl = 42rem，672→756→840px，中文行宽仍在舒适区）。
+  const cases = [
+    { width: 1440, root: 16, terminal: 14, rowTitle: 16, column: 672 },
+    { width: 1919, root: 16, terminal: 14, rowTitle: 16, column: 672 },
+    { width: 1920, root: 18, terminal: 15.75, rowTitle: 18, column: 756 },
+    { width: 2559, root: 18, terminal: 15.75, rowTitle: 18, column: 756 },
+    { width: 2560, root: 20, terminal: 17.5, rowTitle: 20, column: 840 },
+    { width: 3840, root: 20, terminal: 17.5, rowTitle: 20, column: 840 },
+  ]
+
+  for (const c of cases) {
+    const context = await browser.newContext({ viewport: { width: c.width, height: 900 } })
+    const page = await context.newPage()
+    await page.goto('/')
+
+    // 根字号（html computed font-size）
+    const root = parseFloat(
+      await page.locator('html').evaluate((el) => getComputedStyle(el).fontSize),
+    )
+    expect(root).toBe(c.root)
+
+    // 正文/终端/文章行随根字号等比缩放：hero 终端 0.875rem、文章行标题 1rem
+    const terminalFont = parseFloat(
+      await page.locator('.hero-terminal').evaluate((el) => getComputedStyle(el).fontSize),
+    )
+    expect(terminalFont).toBeCloseTo(c.terminal, 5)
+    const rowFont = parseFloat(
+      await page
+        .locator('.post-row-title')
+        .first()
+        .evaluate((el) => getComputedStyle(el).fontSize),
+    )
+    expect(rowFont).toBeCloseTo(c.rowTitle, 5)
+
+    // 内容列宽随 rem 自然变宽（max-w-2xl = 42rem）
+    const columnWidth = await page
+      .locator('.max-w-2xl')
+      .evaluate((el) => el.getBoundingClientRect().width)
+    expect(columnWidth).toBeCloseTo(c.column, 1)
+
+    await context.close()
+  }
+})
+
 test('homepage renders dots canvas: fixed layer that never blocks interaction, homepage-only', async ({
   page,
   request,


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

实现高分屏根字号阶梯缩放：在 src/index.css 新增纯 CSS 媒体查询（≥1920px → html 18px、≥2560px → 20px，以下保持 16px），所有 rem 单位（正文/终端/文章行/42rem 内容列宽 672→756→840px）等比放大；新增 e2e viewport 断言用例，无 JS/组件改动，typecheck/lint/单元/全量 e2e 50 项全部通过，已提交 46b09b2（Ralph: issue-26）

Closes #26