### PR TITLE
fix: issue #27 首页背景点阵克制度

### DIFF
--- a/src/components/BackgroundDots.tsx
+++ b/src/components/BackgroundDots.tsx
@@ -40,22 +40,22 @@ function noise2(x: number, y: number): number {
   )
 }
 
-/* ---------- 动画参数（比原版更疏、透明度更低，控制 CPU 与视觉克制度） ---------- */
+/* ---------- 动画参数（issue #27 克制度：点阵退为若有若无的底噪；同时控制 CPU 与视觉克制度） ---------- */
 
-/** 点距（CSS px）：稀疏网格，避免高密度点阵的 CPU 高占用（antfu/antfu.me#86 教训） */
-const SPACING = 36
+/** 点距（CSS px）：更疏的稀疏网格，避免高密度点阵的 CPU 高占用（antfu/antfu.me#86 教训） */
+export const SPACING = 44
 /** 噪声空间缩放：越小越平缓 */
 const NOISE_SCALE = 0.005
 /** 时间缩放：漂移速度 */
 const TIME_SCALE = 0.0008
-/** 漂移振幅上限（CSS px） */
-const AMPLITUDE = 32
-/** 点直径范围（CSS px） */
-const MIN_SIZE = 1.5
-const MAX_SIZE = 3
-/** 透明度范围：低透明度闪烁，不抢戏 */
-const MIN_ALPHA = 0.1
-const MAX_ALPHA = 0.5
+/** 漂移振幅上限（CSS px）：32→20，更克制的漂移 */
+export const AMPLITUDE = 20
+/** 点直径范围（CSS px）：1.5–3→1–1.8，更细 */
+export const MIN_SIZE = 1
+export const MAX_SIZE = 1.8
+/** 透明度范围（0.1–0.5→0.06–0.22）：上限显著压低，肉眼为暗点而非光斑 */
+export const MIN_ALPHA = 0.06
+export const MAX_ALPHA = 0.22
 
 /** 每个点：基点（网格交点）+ 直径；动画在基点附近做有界漂移 */
 interface Dot {

--- a/tests/unit/background-dots.test.ts
+++ b/tests/unit/background-dots.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AMPLITUDE,
+  MAX_ALPHA,
+  MAX_SIZE,
+  MIN_ALPHA,
+  MIN_SIZE,
+  SPACING,
+} from '../../src/components/BackgroundDots.tsx'
+
+/**
+ * issue #27：首页背景点阵克制度——点阵从"显眼"退为若有若无的底噪。
+ * 这里把克制度规格固化为回归测试，防止后续调参时点阵重新变抢戏。
+ * （视觉契约：点距更疏、点更小更暗、漂移振幅更小；动画行为本身由 e2e 断言）
+ */
+describe('background dots tuning (issue #27)', () => {
+  it('spacing is 44px（36→44，更疏的稀疏网格）', () => {
+    expect(SPACING).toBe(44)
+  })
+
+  it('dot size range is 1–1.8px（1.5–3→1–1.8，更细）', () => {
+    expect(MIN_SIZE).toBe(1)
+    expect(MAX_SIZE).toBe(1.8)
+  })
+
+  it('alpha range is 0.06–0.22（0.1–0.5→0.06–0.22，上限显著压低，肉眼为暗点而非光斑）', () => {
+    expect(MIN_ALPHA).toBe(0.06)
+    expect(MAX_ALPHA).toBe(0.22)
+  })
+
+  it('drift amplitude is 20px（32→20，更克制的漂移）', () => {
+    expect(AMPLITUDE).toBe(20)
+  })
+})


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

首页背景点阵克制度：SPACING 36→44、点径 1.5–3→1–1.8px、透明度 0.1–0.5→0.06–0.22、漂移振幅 32→20px（src/components/BackgroundDots.tsx），漂移/明灭动画与全部既有契约（reduced-motion 不渲染、DPR≤2、后台暂停、--color-dot 主题切换）保持不变；新增 tests/unit/background-dots.test.ts 将克制度规格固化为回归断言，typecheck/lint/26 单元测试/50 e2e 全绿，已提交 bc74ca9

Closes #27