### PR TITLE
fix: issue #29 文章页三栏布局 + 左栏文章索引

### DIFF
--- a/src/components/PostIndex.tsx
+++ b/src/components/PostIndex.tsx
@@ -1,0 +1,38 @@
+import { NavLink } from 'react-router'
+
+import { posts } from '../content/index.ts'
+
+/** 索引行类名：行形态复用首页终端行（.post-row），当前文章追加 nav-active——
+ *  全站导航高亮机制（加粗 + 下划线，见 index.css .post-index a.nav-active，
+ *  与顶部导航 .site-nav a.nav-active 同一令牌） */
+const indexLinkClass = ({ isActive }: { isActive: boolean }) =>
+  `post-row${isActive ? ' nav-active' : ''}`
+
+/**
+ * 文章页左栏文章索引（issue #29）：sticky 常驻全部文章列表，
+ * 与首页终端行同构（mono 日期 + 标题，日期倒序由内容清单保证），
+ * 当前文章加粗 + 下划线高亮（NavLink 自动注入 aria-current="page"）。
+ * <768px 由 CSS 隐藏（抽屉交互由后续工单接入），仅渲染于文章页。
+ */
+export default function PostIndex() {
+  return (
+    <nav aria-label="文章索引" className="post-index">
+      <ul className="post-row-list">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <NavLink to={`/posts/${post.slug}`} className={indexLinkClass}>
+              {/* 行首终端提示符：装饰性（aria-hidden），与首页终端行同构（hover/focus 淡入） */}
+              <span className="post-row-prompt" aria-hidden="true">
+                &gt;
+              </span>
+              <time dateTime={post.date} className="post-row-date">
+                {post.date}
+              </time>
+              <span className="post-row-title">{post.title}</span>
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -552,6 +552,55 @@ html.dark .terminal-dot--green {
   color: var(--color-muted);
 }
 
+/* ===== 文章页两栏布局（issue #29）：左栏文章索引 + 中栏正文 ===== */
+
+/* 两栏网格（≥768px）：左栏 15rem 常驻文章索引 + 中栏正文（minmax 收窄），
+   右缘空位为未来右栏（目录）预留（issue #28 三栏地基） */
+.post-layout {
+  display: grid;
+  grid-template-columns: 15rem minmax(0, 1fr);
+  gap: 2.5rem;
+  /* 子项各自撑高（不拉伸）：sticky 才有所在轨道内的滚动余量 */
+  align-items: start;
+}
+
+/* 左栏：sticky 常驻，跟随滚动至正文末尾（top 2rem 与页内间距同节奏）；
+   列表与首页终端行同构（mono 日期 + 标题，复用 .post-row 行形态） */
+.post-index {
+  position: sticky;
+  top: 2rem;
+}
+.post-index .post-row-list {
+  margin-top: 0;
+}
+
+/* 当前文章高亮（复用全站导航高亮机制）：加粗 + 下划线；
+   行基态与 .post-row 一致（常规字重、无下划线），active 时切换。
+   NavLink 同时注入 aria-current="page"（键盘/读屏可达） */
+.post-index a.nav-active {
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+/* 中栏正文：自然收窄至 ~600px（37.5rem，中文 ~35 字/行）阅读宽度 */
+.post-main {
+  max-width: 37.5rem;
+}
+
+/* <768px：退回单栏——左栏索引隐藏（抽屉交互由后续工单接入），
+   正文居中小于 768px 视口仍保持 ~600px 可读宽度（旧 max-w-2xl 居中视觉不回归） */
+@media (max-width: 767px) {
+  .post-layout {
+    display: block;
+  }
+  .post-index {
+    display: none;
+  }
+  .post-main {
+    margin-inline: auto;
+  }
+}
+
 /* 正文：层级 + 留白节奏 + 独立成块——h2/h3、段落、列表、引用、表格、代码块、行内代码
    各有明确层级与间距（不再全部 16px/零 margin） */
 .post-body {

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from 'react-router'
 
+import PostIndex from '../components/PostIndex.tsx'
 import { posts } from '../content/index.ts'
 import NotFound from './NotFound.tsx'
 
@@ -8,10 +9,13 @@ import NotFound from './NotFound.tsx'
  * 客户端经 dangerouslySetInnerHTML 挂载，同一字符串服务端/客户端完全一致，
  * 从根上避免 hydration mismatch（PRD「渲染策略」决策）。
  *
+ * 两栏布局（issue #29，≥768px）：左栏 sticky 常驻全文章索引（PostIndex，
+ * 与首页终端行同构、当前文章加粗 + 下划线高亮），中栏正文自然收窄至 ~600px
+ * 阅读宽度（37.5rem，中文 ~35 字/行）；<768px 退回单栏（抽屉交互后续接入）。
  * 头部信息区（issue #28）：大标题 + mono 日期/updated（有才显示）+ #标签 + 描述；
  * 正文排版为干净 prose 风格（层级/留白/独立成块，见 index.css .post-body），
  * 终端美学保留在首页与列表。内嵌「目录」块保持不变（后续工单移除）。
- * 正文列维持 42rem 居中——全站容器放宽为 max-w-6xl 后，文章页为未来三栏布局的中间栏。
+ * 上一篇/下一篇保留在正文底部（issue #29）。
  */
 export default function PostPage() {
   const { slug } = useParams()
@@ -27,62 +31,66 @@ export default function PostPage() {
   const older = posts[postIndex + 1]
 
   return (
-    <article className="mx-auto max-w-2xl">
-      {/* 头部信息区：大标题 + mono 元数据（日期/updated/#标签）+ 描述，与正文以细线分隔 */}
-      <header className="post-header">
-        <h1 className="post-title">{post.title}</h1>
-        <div className="post-meta">
-          <time dateTime={post.date}>{post.date}</time>
-          {post.updated && (
-            <>
-              <span aria-hidden="true">·</span>
-              <span className="post-updated">
-                updated <time dateTime={post.updated}>{post.updated}</time>
-              </span>
-            </>
-          )}
-        </div>
-        {post.tags.length > 0 && (
-          <div className="post-tags" aria-label="标签">
-            {post.tags.map((tag) => (
-              <span key={tag} className="post-tag">
-                #{tag}
-              </span>
-            ))}
+    <div className="post-layout">
+      {/* 左栏：sticky 常驻全文章索引（issue #29）；<768px 隐藏（抽屉交互后续接入） */}
+      <PostIndex />
+      <article className="post-main">
+        {/* 头部信息区：大标题 + mono 元数据（日期/updated/#标签）+ 描述，与正文以细线分隔 */}
+        <header className="post-header">
+          <h1 className="post-title">{post.title}</h1>
+          <div className="post-meta">
+            <time dateTime={post.date}>{post.date}</time>
+            {post.updated && (
+              <>
+                <span aria-hidden="true">·</span>
+                <span className="post-updated">
+                  updated <time dateTime={post.updated}>{post.updated}</time>
+                </span>
+              </>
+            )}
           </div>
+          {post.tags.length > 0 && (
+            <div className="post-tags" aria-label="标签">
+              {post.tags.map((tag) => (
+                <span key={tag} className="post-tag">
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          )}
+          {post.description && <p className="post-description">{post.description}</p>}
+        </header>
+
+        {post.toc.length > 0 && (
+          <nav aria-label="文章目录">
+            <h2>目录</h2>
+            <ul>
+              {post.toc.map((item) => (
+                <li key={item.id} className={item.level === 3 ? 'pl-4' : undefined}>
+                  <a href={`#${item.id}`}>{item.text}</a>
+                </li>
+              ))}
+            </ul>
+          </nav>
         )}
-        {post.description && <p className="post-description">{post.description}</p>}
-      </header>
 
-      {post.toc.length > 0 && (
-        <nav aria-label="文章目录">
-          <h2>目录</h2>
-          <ul>
-            {post.toc.map((item) => (
-              <li key={item.id} className={item.level === 3 ? 'pl-4' : undefined}>
-                <a href={`#${item.id}`}>{item.text}</a>
-              </li>
-            ))}
-          </ul>
-        </nav>
-      )}
+        <div className="post-body" dangerouslySetInnerHTML={{ __html: post.html }} />
 
-      <div className="post-body" dangerouslySetInnerHTML={{ __html: post.html }} />
-
-      {(newer || older) && (
-        <nav aria-label="上一篇/下一篇">
-          {newer && (
-            <p>
-              <Link to={`/posts/${newer.slug}`}>上一篇：{newer.title}</Link>
-            </p>
-          )}
-          {older && (
-            <p>
-              <Link to={`/posts/${older.slug}`}>下一篇：{older.title}</Link>
-            </p>
-          )}
-        </nav>
-      )}
-    </article>
+        {(newer || older) && (
+          <nav aria-label="上一篇/下一篇">
+            {newer && (
+              <p>
+                <Link to={`/posts/${newer.slug}`}>上一篇：{newer.title}</Link>
+              </p>
+            )}
+            {older && (
+              <p>
+                <Link to={`/posts/${older.slug}`}>下一篇：{older.title}</Link>
+              </p>
+            )}
+          </nav>
+        )}
+      </article>
+    </div>
   )
 }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -478,7 +478,8 @@ test('post page renders title, date and body content', async ({ page }) => {
   await page.goto('/posts/hello-world')
 
   await expect(page.getByRole('heading', { name: '你好，世界' })).toBeVisible()
-  await expect(page.getByText('2026-08-10')).toBeVisible()
+  // 日期在头部信息区与左栏文章索引重复出现（issue #29）：限定头部，避免 strict-mode 冲突
+  await expect(page.locator('.post-header time').first()).toHaveText('2026-08-10')
   await expect(page.getByText('这是 hacxy.cn 重建后的第一篇文章')).toBeVisible()
 })
 
@@ -1291,9 +1292,92 @@ test('layout foundation: outer container widens to max-w-6xl; homepage/about con
     await page.locator('.max-w-2xl').evaluate((el) => el.getBoundingClientRect().width),
   ).toBeCloseTo(672, 1)
 
-  // 文章页正文列同样为可读宽度（未来三栏布局的中间栏地基）
+  // 文章页：左栏索引 + 中栏正文两栏（issue #29），正文列自然收窄至 ~600px 阅读宽度
   await page.goto('/posts/prerendered-blog-with-vite')
+  await expect(page.getByRole('navigation', { name: '文章索引' })).toBeVisible()
   expect(
     await page.locator('article').evaluate((el) => el.getBoundingClientRect().width),
-  ).toBeCloseTo(672, 1)
+  ).toBeCloseTo(600, 1)
+})
+
+test('post page left index: full list date desc, current highlighted, sticky, clickable; <768px single column (issue #29)', async ({
+  page,
+}) => {
+  // 期望值：从内容源计算（与内容清单同一契约：非 draft、日期倒序）
+  const postsDir = new URL('../../content/posts/', import.meta.url)
+  const published = readdirSync(postsDir)
+    .filter((file) => file.endsWith('.md'))
+    .map((file) => {
+      const data = matter(readFileSync(new URL(file, postsDir), 'utf8')).data
+      return {
+        slug: file.replace(/\.md$/, ''),
+        title: data.title ?? '',
+        date: normalizeDate(data.date),
+        draft: data.draft ?? false,
+      }
+    })
+    .filter((post) => !post.draft)
+    .sort((a, b) => (a.date < b.date ? 1 : -1)) // 日期倒序（最新在前）
+
+  // ≥768px：两栏生效（1280px 视口下断言左栏索引）
+  await page.setViewportSize({ width: 1280, height: 900 })
+  await page.goto('/posts/prerendered-blog-with-vite')
+
+  const index = page.getByRole('navigation', { name: '文章索引' })
+  await expect(index).toBeVisible()
+
+  // 全文章列表：数量与内容源一致
+  const rows = index.locator('.post-row')
+  await expect(rows).toHaveCount(published.length)
+
+  // 日期倒序：最新文章在最前
+  await expect(rows.first().locator('.post-row-date')).toHaveText(published[0]?.date ?? '')
+  await expect(rows.first().locator('.post-row-title')).toHaveText(published[0]?.title ?? '')
+
+  // 每行 = mono 日期 + 标题（与首页终端行同构），指向对应文章页
+  for (const post of published) {
+    const row = rows.filter({ hasText: post.title })
+    await expect(row).toHaveAttribute('href', `/posts/${post.slug}`)
+    await expect(row.locator('.post-row-date')).toHaveText(post.date)
+    expect(
+      await row.locator('.post-row-date').evaluate((el) => getComputedStyle(el).fontFamily),
+    ).toContain('JetBrains Mono')
+    await expect(row.locator('.post-row-title')).toHaveText(post.title)
+  }
+
+  // 当前文章高亮：复用全站导航高亮机制（加粗 + 下划线）+ aria-current="page"
+  const current = rows.filter({ hasText: '用 React + Vite 搭一个构建期预渲染的静态博客' })
+  await expect(current).toHaveClass(/nav-active/)
+  await expect(current).toHaveAttribute('aria-current', 'page')
+  expect(await current.evaluate((el) => getComputedStyle(el).fontWeight)).toBe('700')
+  expect(await current.evaluate((el) => getComputedStyle(el).textDecorationLine)).toContain(
+    'underline',
+  )
+  // 非当前行保持常规字重（不高亮）
+  expect(
+    await rows.filter({ hasText: '第二篇文章' }).evaluate((el) => getComputedStyle(el).fontWeight),
+  ).toBe('400')
+
+  // 左栏 sticky 跟随滚动：滚动到正文底部后索引仍固定在视口内（top = sticky 偏移）
+  expect(await index.evaluate((el) => getComputedStyle(el).position)).toBe('sticky')
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+  const stickyBox = await index.evaluate((el) => {
+    const r = el.getBoundingClientRect()
+    return { top: r.top, bottom: r.bottom }
+  })
+  expect(stickyBox.top).toBeGreaterThanOrEqual(0)
+  expect(stickyBox.top).toBeLessThan(200)
+  expect(stickyBox.bottom).toBeLessThanOrEqual(900)
+
+  // 点击任一行跳转对应文章页
+  await rows.filter({ hasText: '第二篇文章' }).click()
+  await expect(page).toHaveURL(/\/posts\/second-post/)
+
+  // <768px：退回单栏——左栏索引隐藏（抽屉交互由后续工单接入），无横向溢出
+  await page.setViewportSize({ width: 600, height: 800 })
+  await expect(index).toBeHidden()
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  )
+  expect(overflow).toBe(false)
 })


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

实现 issue #29：文章页改为两栏布局（≥768px）——新增 PostIndex 左栏 sticky 常驻全文章索引（复用 .post-row 终端行形态、日期倒序、当前文章 nav-active 加粗+下划线高亮），中栏正文收窄至 ~600px，<768px 退回单栏且首页零回归；同时修复日期在头部/左栏重复导致的 e2e strict-mode 冲突并新增左栏专项断言，55 个 e2e + 26 个单元测试全绿，已提交 e28d4cb（Ralph: issue-29）。

Closes #29