### PR TITLE
fix: issue #31 移动端抽屉：导航按钮 + 覆盖式抽屉

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+
+interface DrawerProps {
+  /** 是否打开：打开时锁定正文滚动、焦点移入抽屉；关闭时卸载内容并还原 */
+  open: boolean
+  /** 滑出方向：左（文章索引）/ 右（目录） */
+  side: 'left' | 'right'
+  /** 抽屉语义标签（role="dialog" 的 aria-label） */
+  label: string
+  onClose: () => void
+  children: ReactNode
+}
+
+/**
+ * 覆盖式抽屉容器（issue #31）：移动端侧栏收进抽屉后的通用骨架。
+ * - 遮罩点击 / Esc / 关闭按钮均可收起；
+ * - 打开时锁定正文滚动（html overflow: hidden，关闭还原）；
+ * - 打开时焦点移入关闭按钮、Tab 焦点循环在抽屉内（键盘无障碍），
+ *   关闭后焦点归还触发按钮；
+ * - 关闭时不渲染内容（条件挂载）：抽屉内容不进可访问性树、不占 Tab 序；
+ *   滑入/淡入为纯 CSS 挂载动画（prefers-reduced-motion 下禁用）。
+ */
+export default function Drawer({ open, side, label, onClose, children }: DrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    // 打开前的正文滚动状态（关闭时还原）；记录触发按钮（关闭后焦点归还）。
+    // 锁在 documentElement 而非 body：body 上 overflow:hidden 会把视口滚动容器
+    // 让位给 body、重置滚动位置到顶部（Chromium），html 上锁定则保留滚动位置。
+    const prevOverflow = document.documentElement.style.overflow
+    document.documentElement.style.overflow = 'hidden'
+    const trigger = document.activeElement instanceof HTMLElement ? document.activeElement : null
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+        return
+      }
+      // Tab 焦点陷阱：循环在抽屉内可聚焦元素之间
+      if (event.key !== 'Tab') return
+      const focusables = panelRef.current?.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )
+      if (!focusables || focusables.length === 0) return
+      const first = focusables.item(0)
+      const last = focusables.item(focusables.length - 1)
+      if (!first || !last) return
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+
+    // 打开时焦点移入抽屉（关闭按钮）
+    closeRef.current?.focus()
+
+    return () => {
+      document.documentElement.style.overflow = prevOverflow
+      document.removeEventListener('keydown', onKeyDown)
+      trigger?.focus()
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div className="drawer" role="dialog" aria-modal="true" aria-label={label}>
+      {/* 遮罩：点击收起（面板之下、正文之上） */}
+      <div className="drawer-overlay" onClick={onClose} />
+      <div ref={panelRef} className={`drawer-panel drawer-panel--${side}`}>
+        <button
+          ref={closeRef}
+          type="button"
+          className="drawer-close"
+          aria-label="关闭"
+          onClick={onClose}
+        >
+          ×
+        </button>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/PostDrawerNav.tsx
+++ b/src/components/PostDrawerNav.tsx
@@ -1,0 +1,54 @@
+import type { TocItem } from '../content/types.ts'
+
+import { useState } from 'react'
+
+import Drawer from './Drawer.tsx'
+import PostIndex from './PostIndex.tsx'
+import PostToc from './PostToc.tsx'
+
+/**
+ * 文章页抽屉导航（issue #31）：窄屏下侧栏收进覆盖式抽屉。
+ * 仅文章页渲染（PostPage 挂载；首页/关于页不渲染）：
+ * - <1024px「目录」按钮可见（右栏收进抽屉）；<768px「文章」按钮也可见（左栏同步收进）；
+ * - ≥1024px 按钮条整条隐藏（display:none → 不占 Tab 序），桌面侧栏常驻；
+ * - 抽屉内容复用桌面侧栏组件（PostIndex / PostToc）：当前文章高亮（NavLink）
+ *   与 scroll-spy（IntersectionObserver）与桌面一致；
+ * - 两个抽屉互斥（同时只开一个），关闭方式 = 遮罩 / Esc / 关闭按钮。
+ */
+export default function PostDrawerNav({ toc }: { toc: TocItem[] }) {
+  const [active, setActive] = useState<'index' | 'toc' | null>(null)
+  const close = () => setActive(null)
+
+  return (
+    <>
+      <div className="post-drawer-bar">
+        <button
+          type="button"
+          className="drawer-trigger drawer-trigger--index"
+          aria-haspopup="dialog"
+          aria-expanded={active === 'index'}
+          onClick={() => setActive('index')}
+        >
+          文章
+        </button>
+        {toc.length > 0 && (
+          <button
+            type="button"
+            className="drawer-trigger drawer-trigger--toc"
+            aria-haspopup="dialog"
+            aria-expanded={active === 'toc'}
+            onClick={() => setActive('toc')}
+          >
+            目录
+          </button>
+        )}
+      </div>
+      <Drawer open={active === 'index'} side="left" label="文章索引" onClose={close}>
+        <PostIndex />
+      </Drawer>
+      <Drawer open={active === 'toc'} side="right" label="文章目录" onClose={close}>
+        <PostToc toc={toc} />
+      </Drawer>
+    </>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -667,6 +667,154 @@ html.dark .terminal-dot--green {
   padding-left: 1rem;
 }
 
+/* ===== 文章页抽屉导航（issue #31）：窄屏侧栏收进覆盖式抽屉 ===== */
+
+/* 按钮条：仅文章页渲染（PostPage 挂载）；<1024px 可见，≥1024px 整条隐藏
+   （桌面侧栏常驻、按钮 display:none 不占 Tab 序）。768–1023px 无目录文章
+   时整条隐藏：「文章」按钮该区间隐藏、目录按钮不渲染 → 空栏不占位 */
+.post-drawer-bar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+@media (min-width: 1024px) {
+  .post-drawer-bar {
+    display: none;
+  }
+}
+@media (min-width: 768px) {
+  .post-drawer-bar:not(:has(.drawer-trigger--toc)) {
+    display: none;
+  }
+}
+
+/* 「文章」按钮：仅 <768px 可见（左栏同步收进抽屉；768–1023px 左栏仍为两栏常驻侧栏） */
+.drawer-trigger--index {
+  display: none;
+}
+@media (max-width: 767px) {
+  .drawer-trigger--index {
+    display: inline-flex;
+  }
+}
+
+/* 触发按钮：终端风格（mono + 边框 + 灰底），hover 反白与全站交互一致；
+   打开的抽屉对应按钮加粗 + 下划线（沿用导航高亮机制） */
+.drawer-trigger {
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--color-prose-border);
+  border-radius: 0.25rem;
+  background-color: var(--color-prose-bg);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--color-accent);
+}
+.drawer-trigger:hover {
+  background-color: var(--color-accent);
+  color: var(--color-accent-contrast);
+}
+.drawer-trigger[aria-expanded='true'] {
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+/* 抽屉骨架：fixed 铺满视口（遮罩 + 面板同层，盖住正文） */
+.drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+}
+
+/* 遮罩：半透明黑、点击收起；淡入（挂载动画，reduced-motion 禁用） */
+.drawer-overlay {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
+  animation: drawer-fade 0.2s ease-out;
+}
+@keyframes drawer-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* 面板：从对应侧滑入（挂载动画，reduced-motion 禁用）；内容纵向滚动、
+   滚动不穿透到正文（overscroll-behavior）；宽度不超视口（375px 无横向滚动） */
+.drawer-panel {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: min(20rem, 100%);
+  padding: 0.875rem;
+  background-color: #ffffff;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  animation: drawer-slide-in 0.25s ease-out;
+}
+html.dark .drawer-panel {
+  background-color: #0a0a0a;
+}
+.drawer-panel--left {
+  left: 0;
+  border-right: 1px solid var(--color-prose-border);
+  animation-name: drawer-slide-left;
+}
+.drawer-panel--right {
+  right: 0;
+  border-left: 1px solid var(--color-prose-border);
+  animation-name: drawer-slide-right;
+}
+@keyframes drawer-slide-left {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+@keyframes drawer-slide-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+/* 关闭按钮：面板右上角（flex 列末尾右对齐）；hover 反白 */
+.drawer-close {
+  align-self: flex-end;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--color-prose-border);
+  border-radius: 0.25rem;
+  background-color: var(--color-prose-bg);
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--color-accent);
+}
+.drawer-close:hover {
+  background-color: var(--color-accent);
+  color: var(--color-accent-contrast);
+}
+
+/* 抽屉内复用桌面侧栏组件：覆盖其 <1024px/<768px 的隐藏与 sticky 定位
+   （面板自身即滚动容器，内容不再 sticky） */
+.drawer-panel .post-index,
+.drawer-panel .post-toc {
+  position: static;
+  display: block;
+}
+
 /* 标题锚点定位偏移（issue #30）：原生 hash 跳转落到标题时预留 2rem
    （与左右 sticky 栏 top 同节奏），配合 html { scroll-behavior: smooth } */
 .post-body h2,
@@ -828,5 +976,10 @@ html.dark .terminal-dot--green {
   /* 行提示符淡入过渡同为动画：reduce 下禁用（提示符/标题反馈本身保留，瞬时切换） */
   .post-row-prompt {
     transition: none;
+  }
+  /* 抽屉：无滑入/淡入动画（瞬时出现收起） */
+  .drawer-overlay,
+  .drawer-panel {
+    animation: none;
   }
 }

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from 'react-router'
 
+import PostDrawerNav from '../components/PostDrawerNav.tsx'
 import PostIndex from '../components/PostIndex.tsx'
 import PostToc from '../components/PostToc.tsx'
 import { posts } from '../content/index.ts'
@@ -15,8 +16,8 @@ import NotFound from './NotFound.tsx'
  * 阅读宽度（37.5rem，中文 ~35 字/行），右栏 sticky 锚点目录（PostToc，
  * h2/h3 两级 + IntersectionObserver scroll-spy 高亮当前章节）；
  * 文章无标题（toc 为空）时右栏整栏隐藏、退化为两栏；<1024px 右栏隐藏，
- * <768px 退回单栏（抽屉交互后续接入）。头部信息区（issue #28）：大标题 +
- * mono 日期/updated（有才显示）+ #标签 + 描述；正文排版为干净 prose 风格
+ * <768px 退回单栏（窄屏侧栏收进覆盖式抽屉，见 PostDrawerNav，issue #31）。
+ * 头部信息区（issue #28）：大标题 + mono 日期/updated（有才显示）+ #标签 + 描述；正文排版为干净 prose 风格
  * （层级/留白/独立成块，见 index.css .post-body），终端美学保留在首页与列表。
  * 内嵌「目录」块已移除（issue #30），TOC 语义（aria-label="文章目录"）保留。
  * 上一篇/下一篇保留在正文底部（issue #29）。
@@ -35,57 +36,62 @@ export default function PostPage() {
   const older = posts[postIndex + 1]
 
   return (
-    /* toc 为空（文章无 h2/h3 标题）时右栏整栏隐藏、布局退化为两栏（--no-toc） */
-    <div className={post.toc.length > 0 ? 'post-layout' : 'post-layout post-layout--no-toc'}>
-      {/* 左栏：sticky 常驻全文章索引（issue #29）；<768px 隐藏（抽屉交互后续接入） */}
-      <PostIndex />
-      <article className="post-main">
-        {/* 头部信息区：大标题 + mono 元数据（日期/updated/#标签）+ 描述，与正文以细线分隔 */}
-        <header className="post-header">
-          <h1 className="post-title">{post.title}</h1>
-          <div className="post-meta">
-            <time dateTime={post.date}>{post.date}</time>
-            {post.updated && (
-              <>
-                <span aria-hidden="true">·</span>
-                <span className="post-updated">
-                  updated <time dateTime={post.updated}>{post.updated}</time>
-                </span>
-              </>
-            )}
-          </div>
-          {post.tags.length > 0 && (
-            <div className="post-tags" aria-label="标签">
-              {post.tags.map((tag) => (
-                <span key={tag} className="post-tag">
-                  #{tag}
-                </span>
-              ))}
+    <>
+      {/* 抽屉导航（issue #31）：窄屏下侧栏收进覆盖式抽屉；仅文章页渲染，
+          ≥1024px 整条隐藏（桌面侧栏常驻、按钮不占 Tab 序） */}
+      <PostDrawerNav toc={post.toc} />
+      {/* toc 为空（文章无 h2/h3 标题）时右栏整栏隐藏、布局退化为两栏（--no-toc） */}
+      <div className={post.toc.length > 0 ? 'post-layout' : 'post-layout post-layout--no-toc'}>
+        {/* 左栏：sticky 常驻全文章索引（issue #29）；<768px 隐藏（抽屉交互后续接入） */}
+        <PostIndex />
+        <article className="post-main">
+          {/* 头部信息区：大标题 + mono 元数据（日期/updated/#标签）+ 描述，与正文以细线分隔 */}
+          <header className="post-header">
+            <h1 className="post-title">{post.title}</h1>
+            <div className="post-meta">
+              <time dateTime={post.date}>{post.date}</time>
+              {post.updated && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span className="post-updated">
+                    updated <time dateTime={post.updated}>{post.updated}</time>
+                  </span>
+                </>
+              )}
             </div>
+            {post.tags.length > 0 && (
+              <div className="post-tags" aria-label="标签">
+                {post.tags.map((tag) => (
+                  <span key={tag} className="post-tag">
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            )}
+            {post.description && <p className="post-description">{post.description}</p>}
+          </header>
+
+          <div className="post-body" dangerouslySetInnerHTML={{ __html: post.html }} />
+
+          {(newer || older) && (
+            <nav aria-label="上一篇/下一篇">
+              {newer && (
+                <p>
+                  <Link to={`/posts/${newer.slug}`}>上一篇：{newer.title}</Link>
+                </p>
+              )}
+              {older && (
+                <p>
+                  <Link to={`/posts/${older.slug}`}>下一篇：{older.title}</Link>
+                </p>
+              )}
+            </nav>
           )}
-          {post.description && <p className="post-description">{post.description}</p>}
-        </header>
-
-        <div className="post-body" dangerouslySetInnerHTML={{ __html: post.html }} />
-
-        {(newer || older) && (
-          <nav aria-label="上一篇/下一篇">
-            {newer && (
-              <p>
-                <Link to={`/posts/${newer.slug}`}>上一篇：{newer.title}</Link>
-              </p>
-            )}
-            {older && (
-              <p>
-                <Link to={`/posts/${older.slug}`}>下一篇：{older.title}</Link>
-              </p>
-            )}
-          </nav>
-        )}
-      </article>
-      {/* 右栏：sticky 锚点目录 + scroll-spy（issue #30）；仅文章有标题时渲染，
+        </article>
+        {/* 右栏：sticky 锚点目录 + scroll-spy（issue #30）；仅文章有标题时渲染，
           <1024px 由 CSS 隐藏，toc 为空时整栏不渲染（布局退化为两栏） */}
-      {post.toc.length > 0 && <PostToc toc={post.toc} />}
-    </div>
+        {post.toc.length > 0 && <PostToc toc={post.toc} />}
+      </div>
+    </>
   )
 }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1504,3 +1504,205 @@ test('post page left index: full list date desc, current highlighted, sticky, cl
   )
   expect(overflow).toBe(false)
 })
+
+/* ===== 移动端抽屉（issue #31）：窄屏侧栏收进覆盖式抽屉 ===== */
+
+test('mobile drawer: <1024px 目录 button opens right TOC drawer with working scroll-spy; overlay/Esc/close dismiss (issue #31)', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1000, height: 800 })
+  await page.goto('/posts/prerendered-blog-with-vite')
+
+  // <1024px：「目录」按钮可见，「文章」按钮隐藏（768–1023px 左栏仍为两栏常驻侧栏）
+  const tocTrigger = page.getByRole('button', { name: '目录' })
+  await expect(tocTrigger).toBeVisible()
+  await expect(page.getByRole('button', { name: '文章', exact: true })).toHaveCount(0)
+  // 桌面右栏整栏隐藏（功能收进抽屉）
+  await expect(page.locator('.post-toc')).toBeHidden()
+
+  // 点击「目录」→ 右侧抽屉滑出；内容复用桌面目录组件（同一导航语义）
+  await tocTrigger.click()
+  const dialog = page.getByRole('dialog', { name: '文章目录' })
+  await expect(dialog).toBeVisible()
+  const drawerToc = dialog.getByRole('navigation', { name: '文章目录' })
+  await expect(drawerToc).toBeVisible()
+  await expect(drawerToc.getByRole('link', { name: '渲染策略：构建期一次性渲染' })).toBeVisible()
+
+  // 打开时锁定正文滚动；焦点移入抽屉（关闭按钮）；触发按钮标记打开状态
+  expect(await page.evaluate(() => document.documentElement.style.overflow)).toBe('hidden')
+  await expect(page.getByRole('button', { name: '关闭' })).toBeFocused()
+  await expect(tocTrigger).toHaveAttribute('aria-expanded', 'true')
+
+  // Esc 收起：抽屉卸载、滚动还原、焦点归还触发按钮
+  await page.keyboard.press('Escape')
+  await expect(dialog).toHaveCount(0)
+  expect(await page.evaluate(() => document.documentElement.style.overflow)).toBe('')
+  await expect(tocTrigger).toBeFocused()
+
+  // 抽屉内 scroll-spy 与桌面一致：先滚动到「踩过的坑」位于观察带，再打开抽屉 → 该项高亮
+  // （用 el.click() 打开避免 Playwright 自动滚动回触发按钮、破坏滚动位置）
+  await page.evaluate(() => {
+    const heading = document.getElementById('踩过的坑') as HTMLElement
+    const y = heading.getBoundingClientRect().top + window.scrollY - window.innerHeight * 0.35
+    window.scrollTo({ top: y, behavior: 'instant' })
+  })
+  await tocTrigger.evaluate((el) => (el as HTMLElement).click())
+  await expect(dialog).toBeVisible()
+  await expect(drawerToc.getByRole('link', { name: '踩过的坑' })).toHaveClass(/post-toc-active/)
+
+  // 遮罩点击收起
+  await page.locator('.drawer-overlay').click({ position: { x: 20, y: 400 } })
+  await expect(dialog).toHaveCount(0)
+
+  // 关闭按钮收起（焦点归还）
+  await tocTrigger.click()
+  await expect(dialog).toBeVisible()
+  await page.getByRole('button', { name: '关闭' }).click()
+  await expect(dialog).toHaveCount(0)
+  await expect(tocTrigger).toBeFocused()
+})
+
+test('mobile drawer: <768px 文章 button opens left index drawer; current article highlighted; row click navigates (issue #31)', async ({
+  page,
+}) => {
+  // 期望值从内容源计算（与内容清单同一契约：非 draft 文章、日期倒序）
+  const postsDir = new URL('../../content/posts/', import.meta.url)
+  const published = readdirSync(postsDir)
+    .filter((file) => file.endsWith('.md'))
+    .map((file) => matter(readFileSync(new URL(file, postsDir), 'utf8')))
+    .filter((parsed) => !parsed.data.draft)
+    .sort((a, b) => (normalizeDate(a.data.date) < normalizeDate(b.data.date) ? 1 : -1))
+
+  await page.setViewportSize({ width: 600, height: 800 })
+  await page.goto('/posts/prerendered-blog-with-vite')
+
+  // <768px：两个按钮都可见；桌面左栏整栏隐藏（功能收进抽屉）
+  await expect(page.getByRole('button', { name: '目录' })).toBeVisible()
+  const indexTrigger = page.getByRole('button', { name: '文章', exact: true })
+  await expect(indexTrigger).toBeVisible()
+  await expect(page.getByRole('navigation', { name: '文章索引' })).toBeHidden()
+
+  // 点击「文章」→ 左侧抽屉滑出；内容复用桌面左栏组件（当前文章高亮 + aria-current）
+  await indexTrigger.click()
+  const dialog = page.getByRole('dialog', { name: '文章索引' })
+  await expect(dialog).toBeVisible()
+  const drawerIndex = dialog.getByRole('navigation', { name: '文章索引' })
+  await expect(drawerIndex).toBeVisible()
+  const current = drawerIndex.getByRole('link', {
+    name: /用 React \+ Vite 搭一个构建期预渲染的静态博客/,
+  })
+  await expect(current).toHaveClass(/nav-active/)
+  await expect(current).toHaveAttribute('aria-current', 'page')
+
+  // 抽屉内容与桌面侧栏一致：全文章列表（数量/顺序与内容源一致）+ mono 日期
+  await expect(drawerIndex.locator('.post-row')).toHaveCount(published.length)
+  await expect(drawerIndex.locator('.post-row-date').first()).toHaveText(
+    normalizeDate(published[0]?.data.date),
+  )
+
+  // 点击抽屉内文章行 → 跳转对应文章页（抽屉随页面卸载）
+  await drawerIndex.getByRole('link', { name: '第二篇文章' }).click()
+  await expect(page).toHaveURL(/\/posts\/second-post/)
+})
+
+test('desktop ≥1024px: drawer buttons hidden (no Tab insertion), sidebars persistent (issue #31)', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 })
+  await page.goto('/posts/prerendered-blog-with-vite')
+
+  // 按钮整条隐藏：display:none → 不进可访问性树、不占 Tab 序
+  await expect(page.getByRole('button', { name: '目录' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: '文章', exact: true })).toHaveCount(0)
+  await expect(page.locator('.post-drawer-bar')).toBeHidden()
+
+  // 侧栏常驻：左索引 + 右目录均可见
+  await expect(page.getByRole('navigation', { name: '文章索引' })).toBeVisible()
+  await expect(page.getByRole('navigation', { name: '文章目录' })).toBeVisible()
+
+  // Tab 顺序无变化：文章 → 关于 → 主题 → GitHub → RSS → 左栏第一行（无抽屉按钮插队）
+  const nav = page.locator('.site-nav')
+  for (let i = 0; i < 4; i++) await page.keyboard.press('Tab')
+  await expect(nav.getByRole('link', { name: 'GitHub' })).toBeFocused()
+  await page.keyboard.press('Tab')
+  await expect(nav.getByRole('link', { name: 'RSS' })).toBeFocused()
+  await page.keyboard.press('Tab')
+  await expect(
+    page.getByRole('navigation', { name: '文章索引' }).locator('.post-row').first(),
+  ).toBeFocused()
+})
+
+test('mobile drawer: body scroll locked while open, restored after close (issue #31)', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 600, height: 800 })
+  await page.goto('/posts/hello-world')
+
+  // 正文初始可滚动（html 无锁定）
+  expect(await page.evaluate(() => document.documentElement.style.overflow)).toBe('')
+
+  // 打开「目录」抽屉：正文滚动锁定——滚轮 / PageDown 均无法滚动正文
+  await page.getByRole('button', { name: '目录' }).click()
+  await expect(page.getByRole('dialog', { name: '文章目录' })).toBeVisible()
+  expect(await page.evaluate(() => document.documentElement.style.overflow)).toBe('hidden')
+  await page.mouse.wheel(0, 500)
+  await page.keyboard.press('PageDown')
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+
+  // 关闭（Esc）后还原：滚动解锁，滚轮可正常滚动
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('dialog', { name: '文章目录' })).toHaveCount(0)
+  expect(await page.evaluate(() => document.documentElement.style.overflow)).toBe('')
+  await page.mouse.wheel(0, 500)
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+
+  // 另一侧抽屉同样锁定/还原
+  await page.getByRole('button', { name: '文章', exact: true }).click()
+  await expect(page.getByRole('dialog', { name: '文章索引' })).toBeVisible()
+  expect(await page.evaluate(() => document.documentElement.style.overflow)).toBe('hidden')
+  const lockedAt = await page.evaluate(() => window.scrollY)
+  await page.mouse.wheel(0, 800)
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(lockedAt)
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('dialog', { name: '文章索引' })).toHaveCount(0)
+  expect(await page.evaluate(() => document.documentElement.style.overflow)).toBe('')
+})
+
+test('mobile drawer: no slide-in animation under prefers-reduced-motion (issue #31)', async ({
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await page.setViewportSize({ width: 600, height: 800 })
+  await page.goto('/posts/prerendered-blog-with-vite')
+
+  await page.getByRole('button', { name: '目录' }).click()
+  const panel = page.locator('.drawer-panel')
+  await expect(panel).toBeVisible()
+  // 无滑入/淡入动画（瞬时出现）
+  expect(await panel.evaluate((el) => getComputedStyle(el).animationName)).toBe('none')
+  expect(
+    await page.locator('.drawer-overlay').evaluate((el) => getComputedStyle(el).animationName),
+  ).toBe('none')
+})
+
+test('homepage renders no drawer buttons; 375px article drawer works with no horizontal overflow (issue #31)', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 375, height: 667 })
+  await page.goto('/')
+
+  // 首页不渲染抽屉按钮（仅文章页渲染）
+  await expect(page.getByRole('button', { name: '目录' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: '文章', exact: true })).toHaveCount(0)
+  await expect(page.locator('.post-drawer-bar')).toHaveCount(0)
+
+  // 文章页 375px：按钮可见、抽屉可开、打开时无横向滚动
+  await page.goto('/posts/prerendered-blog-with-vite')
+  await expect(page.getByRole('button', { name: '目录' })).toBeVisible()
+  await page.getByRole('button', { name: '目录' }).click()
+  await expect(page.getByRole('dialog', { name: '文章目录' })).toBeVisible()
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  )
+  expect(overflow).toBe(false)
+})


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

实现 issue #31 移动端抽屉：新增 Drawer/PostDrawerNav 组件（复用 PostIndex/PostToc），<1024px 目录按钮与 <768px 文章按钮滑出左右抽屉，遮罩/Esc/关闭按钮收起、滚动锁定（锁在 html 保留滚动位置）、reduced-motion 禁用动画、桌面按钮隐藏不占 Tab 序；新增 6 条 e2e 断言，全套 65 e2e + 26 unit + typecheck/lint 全绿，已提交（Ralph: issue-31）未推送。

Closes #31