### PR TITLE
fix: issue #41 内容目录多层嵌套：递归管线 + 嵌套路由 + SEO 跟随

### DIFF
--- a/content/posts/pi-agent/01.md
+++ b/content/posts/pi-agent/01.md
@@ -1,0 +1,22 @@
+---
+title: 什么是 pi agent
+date: 2026-08-12
+description: 嵌套目录文章 fixture（issue #41）：验证任意深度目录的聚合、嵌套路由与 SEO 跟随。
+tags: [pi, 随笔]
+---
+
+pi agent 是一个基于阅读、搜索与写代码的 AI 编程助手：它先读代码、再动手改，所有变更都以可审阅的 git 提交落地。
+
+本文是嵌套目录的 fixture 文章：路径 `content/posts/pi-agent/01.md` 的 slug 为 `pi-agent/01`，URL 为 `/posts/pi-agent/01`——目录任意深度嵌套都能被内容管线递归聚合，canonical / OG / JSON-LD / sitemap / RSS 全部由 slug 自动推导。
+
+## 递归聚合
+
+内容管线从「仅读一层 .md」改为递归扫描：嵌套文章的 slug 等于相对目录路径（不含 .md 后缀），根层文章行为零回归。
+
+## 契约不变
+
+frontmatter 契约保持：date 必填、draft 排除、tags 过滤；缺失字段使用确定性默认值，不引入隐式继承。
+
+## 首页平铺
+
+首页列表仍为全局日期倒序平铺：嵌套文章自动上首页，与根层文章同列表、同排序。

--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -264,5 +264,8 @@ const ogDir = join(distDir, 'og', 'posts')
 mkdirSync(ogDir, { recursive: true })
 writeFileSync(join(distDir, 'og', 'home.svg'), renderOgImage(siteName, tagline))
 for (const post of posts) {
-  writeFileSync(join(ogDir, `${post.slug}.svg`), renderOgImage(siteName, post.title))
+  // 嵌套 slug（如 pi-agent/01）：OG 图路径为 /og/posts/<slug>.svg，需递归建目录
+  const ogFile = join(ogDir, `${post.slug}.svg`)
+  mkdirSync(dirname(ogFile), { recursive: true })
+  writeFileSync(ogFile, renderOgImage(siteName, post.title))
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,8 @@ export function AppRoutes() {
       <Route element={<Layout />}>
         <Route index element={<Home />} />
         <Route path="about" element={<About />} />
-        <Route path="posts/:slug" element={<PostPage />} />
+        {/* splat：嵌套 slug（如 pi-agent/01）经 posts/* 捕获，:slug 不匹配斜杠 */}
+        <Route path="posts/*" element={<PostPage />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>

--- a/src/content/collectSources.ts
+++ b/src/content/collectSources.ts
@@ -1,0 +1,36 @@
+import type { PostSource } from './types.ts'
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+/**
+ * 递归收集目录下全部 .md 文件（绝对路径，任意深度）。
+ * 非 .md 文件（assets/ 等资源）不参与聚合。
+ */
+export function collectMarkdownFiles(postsDir: string): string[] {
+  const files: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        walk(full)
+      } else if (entry.endsWith('.md')) {
+        files.push(full)
+      }
+    }
+  }
+  walk(postsDir)
+  return files
+}
+
+/**
+ * 递归聚合文章源：slug = 相对目录路径（/ 分隔，不含 .md 后缀）。
+ * 任意深度目录（如 pi-agent/01.md → slug "pi-agent/01"）都能被聚合，
+ * 根层文章行为不变（slug = 文件名）；排序由 loadPosts 按 date 完成。
+ */
+export function collectPostSources(postsDir: string): PostSource[] {
+  return collectMarkdownFiles(postsDir).map((file) => ({
+    slug: relative(postsDir, file).split(sep).join('/').replace(/\.md$/, ''),
+    raw: readFileSync(file, 'utf8'),
+  }))
+}

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -23,7 +23,8 @@ import NotFound from './NotFound.tsx'
  * 上一篇/下一篇保留在正文底部（issue #29）。
  */
 export default function PostPage() {
-  const { slug } = useParams()
+  // posts/* splat：嵌套目录 slug（pi-agent/01）原样经通配段捕获
+  const slug = useParams()['*'] ?? ''
   const postIndex = posts.findIndex((item) => item.slug === slug)
   const post = postIndex >= 0 ? posts[postIndex] : undefined
 

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,25 +1,7 @@
 import { expect, test } from '@playwright/test'
-import { readdirSync, readFileSync } from 'node:fs'
-import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
 
-// gray-matter 无类型声明：E2E 仅用它解析 frontmatter 计算期望值（与构建期内容清单同一契约）
-const require = createRequire(import.meta.url)
-const matter = require('gray-matter') as (input: string) => {
-  data: {
-    draft?: boolean
-    tags?: string[]
-    title?: string
-    description?: string
-    /** gray-matter/js-yaml 会把 YYYY-MM-DD 解析为 Date 对象 */
-    date?: string | Date
-  }
-}
-
-/** 与内容管线同一日期契约：Date 对象归一化为 YYYY-MM-DD（ISO） */
-function normalizeDate(value: string | Date | undefined): string {
-  if (!value) return ''
-  return typeof value === 'string' ? value : value.toISOString().slice(0, 10)
-}
+import { publishedPosts } from './posts-helper.ts'
 
 test('hero: big h1 site name + AI agent conversation (three Q&A rounds)', async ({ page }) => {
   await page.goto('/')
@@ -63,13 +45,9 @@ test('hero: big h1 site name + AI agent conversation (three Q&A rounds)', async 
 test('hero terminal: ls posts counts match the content manifest', async ({ page }) => {
   // 期望值从内容源计算（同一契约：非 draft 文章数 + 全站标签并集），
   // 与构建期内容清单的 draft 过滤 / tags 聚合规则一致——新增文章无需改代码
-  const postsDir = new URL('../../content/posts/', import.meta.url)
-  const published = readdirSync(postsDir)
-    .filter((file) => file.endsWith('.md'))
-    .map((file) => matter(readFileSync(new URL(file, postsDir), 'utf8')))
-    .filter((parsed) => !parsed.data.draft)
+  const published = publishedPosts()
   const postCount = published.length
-  const tagCount = new Set(published.flatMap((parsed) => parsed.data.tags ?? [])).size
+  const tagCount = new Set(published.flatMap((post) => post.tags)).size
 
   await page.goto('/')
   const terminal = page.locator('.hero-terminal')
@@ -242,22 +220,7 @@ test('post list: terminal output lines show mono date, title and #tags (no descr
   page,
 }) => {
   // 期望值从内容源计算（与构建期内容清单同一契约：非 draft 文章、日期倒序）
-  const postsDir = new URL('../../content/posts/', import.meta.url)
-  const published = readdirSync(postsDir)
-    .filter((file) => file.endsWith('.md'))
-    .map((file) => {
-      const data = matter(readFileSync(new URL(file, postsDir), 'utf8')).data
-      return {
-        slug: file.replace(/\.md$/, ''),
-        title: data.title ?? '',
-        date: normalizeDate(data.date),
-        description: data.description ?? '',
-        tags: data.tags ?? [],
-        draft: data.draft ?? false,
-      }
-    })
-    .filter((post) => !post.draft)
-    .sort((a, b) => (a.date < b.date ? 1 : -1)) // 内容清单按日期倒序（最新在前）
+  const published = publishedPosts()
 
   await page.goto('/')
   const rows = page.locator('.post-row')
@@ -413,9 +376,9 @@ test('post rows are keyboard reachable: Tab focus, visible focus style, Enter op
   )
   await expect(firstRowLink).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
 
-  // Enter 打开文章
+  // Enter 打开最新文章（期望值从内容源计算，嵌套文章同样可达）
   await page.keyboard.press('Enter')
-  await expect(page).toHaveURL(/\/posts\/prerendered-blog-with-vite/)
+  await expect(page).toHaveURL(new RegExp(`/posts/${publishedPosts()[0]?.slug}`))
 })
 
 test('homepage shows site name and the fixture post', async ({ page }) => {
@@ -627,18 +590,23 @@ test('post page without TOC: right column hidden, layout falls back to two colum
 })
 
 test('prev/next navigation moves between posts', async ({ page }) => {
-  // 最新文章（真实技术文章）无上一篇，下一篇指向 hello-world
-  await page.goto('/posts/prerendered-blog-with-vite')
+  // 期望链从内容源计算（同一契约：非 draft、日期倒序）——新增/嵌套文章自动适配
+  const [newest, middle, older, oldest] = publishedPosts()
+
+  // 最新文章无上一篇，下一篇指向第二新
+  await page.goto(`/posts/${newest?.slug}`)
   await expect(page.getByRole('link', { name: /上一篇/ })).toHaveCount(0)
   await page.getByRole('link', { name: /下一篇/ }).click()
-  await expect(page).toHaveURL(/\/posts\/hello-world/)
+  await expect(page).toHaveURL(new RegExp(`/posts/${middle?.slug}`))
 
-  // hello-world 位于中间：上一篇 = 最新文章，下一篇 = second-post
+  // 中间文章：上一篇/下一篇都有，沿日期倒序翻页
   await expect(page.getByRole('link', { name: /上一篇/ })).toBeVisible()
   await page.getByRole('link', { name: /下一篇/ }).click()
-  await expect(page).toHaveURL(/\/posts\/second-post/)
+  await expect(page).toHaveURL(new RegExp(`/posts/${older?.slug}`))
+  await page.getByRole('link', { name: /下一篇/ }).click()
+  await expect(page).toHaveURL(new RegExp(`/posts/${oldest?.slug}`))
 
-  // 最旧文章（second-post）只有上一篇，没有下一篇
+  // 最旧文章只有上一篇，没有下一篇
   await expect(page.getByRole('link', { name: /上一篇/ })).toBeVisible()
   await expect(page.getByRole('link', { name: /下一篇/ })).toHaveCount(0)
 })
@@ -1000,6 +968,82 @@ test('feed.xml is a valid RSS 2.0 feed with full article content', async ({ requ
 
   // draft 文章不在 feed
   expect(feed).not.toContain('draft-post')
+})
+
+/* ===== 嵌套目录文章（issue #41）：递归聚合 + 嵌套路由 + SEO 跟随 ===== */
+
+test('nested post: /posts/<dir path> opens; prerendered as .html and index.html (issue #41)', async ({
+  request,
+}) => {
+  // 直达嵌套 URL（slug = 相对目录路径）返回 200，源码含正文（爬虫不执行 JS 即可读）
+  const response = await request.get('/posts/pi-agent/01')
+  expect(response.status()).toBe(200)
+  const html = await response.text()
+  expect(html).toContain('什么是 pi agent')
+  expect(html).toContain('递归聚合')
+
+  // 双形态产物：<slug>.html 与 <slug>/index.html 均可访问（与根层文章同一输出契约）
+  const indexHtml = await request.get('/posts/pi-agent/01/')
+  expect(indexHtml.status()).toBe(200)
+  expect(await indexHtml.text()).toContain('什么是 pi agent')
+})
+
+test('nested post: canonical/OG/JSON-LD/sitemap/RSS derive from slug (issue #41)', async ({
+  request,
+}) => {
+  // canonical + og:url 跟随嵌套 slug
+  const post = await (await request.get('/posts/pi-agent/01')).text()
+  expect(post).toContain('rel="canonical" href="https://hacxy.cn/posts/pi-agent/01"')
+  expect(post).toContain('property="og:url" content="https://hacxy.cn/posts/pi-agent/01"')
+
+  // JSON-LD Article：url / mainEntityOfPage 由 slug 推导
+  expect(post).toContain('"@type": "Article"')
+  expect(post).toContain('"url": "https://hacxy.cn/posts/pi-agent/01"')
+  expect(post).toContain('"mainEntityOfPage": "https://hacxy.cn/posts/pi-agent/01"')
+
+  // OG 图：构建期生成于嵌套路径且可访问
+  expect(post).toContain('property="og:image" content="https://hacxy.cn/og/posts/pi-agent/01.svg"')
+  const og = await (await request.get('/og/posts/pi-agent/01.svg')).text()
+  expect(og).toContain('<svg')
+  expect(og).toContain('什么是 pi agent')
+
+  // sitemap 含嵌套 loc
+  const sitemap = await (await request.get('/sitemap.xml')).text()
+  expect(sitemap).toContain('<loc>https://hacxy.cn/posts/pi-agent/01</loc>')
+
+  // RSS 条目链接/guid 跟随嵌套 slug，全文进 content:encoded
+  const feed = await (await request.get('/feed.xml')).text()
+  expect(feed).toContain('<link>https://hacxy.cn/posts/pi-agent/01</link>')
+  expect(feed).toContain('<guid isPermaLink="true">https://hacxy.cn/posts/pi-agent/01</guid>')
+  expect(feed).toContain('<title>什么是 pi agent</title>')
+})
+
+test('nested post: listed on homepage in global date-desc order (issue #41)', async ({ page }) => {
+  const published = publishedPosts()
+
+  await page.goto('/')
+  // 嵌套文章自动上首页（最新在前），行链接指向嵌套 URL
+  const row = page.locator('.post-row').filter({ hasText: '什么是 pi agent' })
+  await expect(row).toBeVisible()
+  await expect(row).toHaveAttribute('href', '/posts/pi-agent/01')
+
+  // 全局日期倒序平铺：首页首行 = 最新文章（与内容源一致）
+  await expect(page.locator('.post-row').first().locator('.post-row-title')).toHaveText(
+    published[0]?.title ?? '',
+  )
+})
+
+test('nested post: opens via client navigation; tops the prev/next chain (issue #41)', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await page.getByRole('link', { name: '什么是 pi agent' }).click()
+  await expect(page).toHaveURL(/\/posts\/pi-agent\/01/)
+  await expect(page.getByRole('heading', { name: '什么是 pi agent' })).toBeVisible()
+
+  // 最新文章无上一篇（嵌套 slug 参与全局排序，上一篇/下一篇链完整）
+  await expect(page.getByRole('link', { name: /上一篇/ })).toHaveCount(0)
+  await expect(page.getByRole('link', { name: /下一篇/ })).toBeVisible()
 })
 
 test('favicon.svg is monochrome (black/white) and consistent with the site theme', async ({
@@ -1427,20 +1471,7 @@ test('post page left index: full list date desc, current highlighted, sticky, cl
   page,
 }) => {
   // 期望值：从内容源计算（与内容清单同一契约：非 draft、日期倒序）
-  const postsDir = new URL('../../content/posts/', import.meta.url)
-  const published = readdirSync(postsDir)
-    .filter((file) => file.endsWith('.md'))
-    .map((file) => {
-      const data = matter(readFileSync(new URL(file, postsDir), 'utf8')).data
-      return {
-        slug: file.replace(/\.md$/, ''),
-        title: data.title ?? '',
-        date: normalizeDate(data.date),
-        draft: data.draft ?? false,
-      }
-    })
-    .filter((post) => !post.draft)
-    .sort((a, b) => (a.date < b.date ? 1 : -1)) // 日期倒序（最新在前）
+  const published = publishedPosts()
 
   // ≥768px：两栏生效（1280px 视口下断言左栏索引）
   await page.setViewportSize({ width: 1280, height: 900 })
@@ -1566,12 +1597,7 @@ test('mobile drawer: <768px 文章 button opens left index drawer; current artic
   page,
 }) => {
   // 期望值从内容源计算（与内容清单同一契约：非 draft 文章、日期倒序）
-  const postsDir = new URL('../../content/posts/', import.meta.url)
-  const published = readdirSync(postsDir)
-    .filter((file) => file.endsWith('.md'))
-    .map((file) => matter(readFileSync(new URL(file, postsDir), 'utf8')))
-    .filter((parsed) => !parsed.data.draft)
-    .sort((a, b) => (normalizeDate(a.data.date) < normalizeDate(b.data.date) ? 1 : -1))
+  const published = publishedPosts()
 
   await page.setViewportSize({ width: 600, height: 800 })
   await page.goto('/posts/prerendered-blog-with-vite')
@@ -1596,9 +1622,7 @@ test('mobile drawer: <768px 文章 button opens left index drawer; current artic
 
   // 抽屉内容与桌面侧栏一致：全文章列表（数量/顺序与内容源一致）+ mono 日期
   await expect(drawerIndex.locator('.post-row')).toHaveCount(published.length)
-  await expect(drawerIndex.locator('.post-row-date').first()).toHaveText(
-    normalizeDate(published[0]?.data.date),
-  )
+  await expect(drawerIndex.locator('.post-row-date').first()).toHaveText(published[0]?.date ?? '')
 
   // 点击抽屉内文章行 → 跳转对应文章页（抽屉随页面卸载）
   await drawerIndex.getByRole('link', { name: '第二篇文章' }).click()

--- a/tests/e2e/posts-helper.ts
+++ b/tests/e2e/posts-helper.ts
@@ -1,0 +1,79 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join, relative, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// gray-matter 无类型声明：E2E 仅用它解析 frontmatter 计算期望值（与构建期内容清单同一契约）
+const require = createRequire(import.meta.url)
+const matter = require('gray-matter') as (input: string) => {
+  data: {
+    draft?: boolean
+    tags?: string[]
+    title?: string
+    description?: string
+    /** gray-matter/js-yaml 会把 YYYY-MM-DD 解析为 Date 对象 */
+    date?: string | Date
+  }
+}
+
+/** 与内容管线同一日期契约：Date 对象归一化为 YYYY-MM-DD（ISO） */
+function normalizeDate(value: string | Date | undefined): string {
+  if (!value) return ''
+  return typeof value === 'string' ? value : value.toISOString().slice(0, 10)
+}
+
+const POSTS_DIR = fileURLToPath(new URL('../../content/posts/', import.meta.url))
+
+/**
+ * 递归收集 content/posts 下全部 .md：slug = 相对目录路径（/ 分隔，不含 .md 后缀）。
+ * 与构建期内容管线同一契约（collectPostSources）：嵌套目录（如 pi-agent/01.md）
+ * 推导出嵌套 slug（pi-agent/01），非 md 文件（assets/ 等）不参与聚合。
+ */
+function collectSources(): { slug: string; raw: string }[] {
+  const sources: { slug: string; raw: string }[] = []
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        walk(full)
+      } else if (entry.endsWith('.md')) {
+        sources.push({
+          slug: relative(POSTS_DIR, full).split(sep).join('/').replace(/\.md$/, ''),
+          raw: readFileSync(full, 'utf8'),
+        })
+      }
+    }
+  }
+  walk(POSTS_DIR)
+  return sources
+}
+
+export interface ExpectedPost {
+  slug: string
+  title: string
+  date: string
+  description: string
+  tags: string[]
+  draft: boolean
+}
+
+/**
+ * 期望文章清单：递归扫描内容源 + frontmatter 解析（与构建期内容清单同一契约：
+ * 非 draft、日期倒序）。全部 e2e 的期望值由此计算——新增/嵌套文章无需改测试代码。
+ */
+export function publishedPosts(): ExpectedPost[] {
+  return collectSources()
+    .map(({ slug, raw }) => {
+      const data = matter(raw).data
+      return {
+        slug,
+        title: data.title ?? '',
+        date: normalizeDate(data.date),
+        description: data.description ?? '',
+        tags: data.tags ?? [],
+        draft: data.draft ?? false,
+      }
+    })
+    .filter((post) => !post.draft)
+    .sort((a, b) => (a.date < b.date ? 1 : -1)) // 内容清单按日期倒序（最新在前）
+}

--- a/tests/unit/collect-sources.test.ts
+++ b/tests/unit/collect-sources.test.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { collectMarkdownFiles, collectPostSources } from '../../src/content/collectSources.ts'
+import { loadPosts } from '../../src/content/loadPosts.ts'
+
+const POSTS_DIR = join(process.cwd(), 'content', 'posts')
+
+describe('collectMarkdownFiles: recursive scan', () => {
+  it('walks nested directories and returns only .md files (arbitrary depth)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'posts-'))
+    try {
+      mkdirSync(join(dir, 'a', 'b', 'c'), { recursive: true })
+      writeFileSync(join(dir, 'a', 'root.md'), '# r')
+      writeFileSync(join(dir, 'a', 'b', 'c', 'deep.md'), '# d')
+      writeFileSync(join(dir, 'a', 'b', 'note.txt'), 'x')
+      writeFileSync(join(dir, 'a', 'b', 'asset.png'), 'x')
+
+      const files = collectMarkdownFiles(dir).map((file) => file.replace(`${dir}/`, ''))
+      expect(files.sort()).toEqual(['a/b/c/deep.md', 'a/root.md'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('aggregates the real content/posts tree including nested and root posts', () => {
+    const files = collectMarkdownFiles(POSTS_DIR)
+    const names = files.map((file) => file.replace(`${POSTS_DIR}/`, ''))
+    // 根层文章
+    expect(names).toContain('hello-world.md')
+    // 嵌套目录文章
+    expect(names).toContain('pi-agent/01.md')
+    // 非 md 资源（assets/ 等）不参与聚合
+    expect(names.some((name) => !name.endsWith('.md'))).toBe(false)
+  })
+})
+
+describe('collectPostSources: slug derivation contract', () => {
+  it('derives nested slug from the relative directory path (no .md suffix)', () => {
+    const slugs = collectPostSources(POSTS_DIR).map((source) => source.slug)
+    // 嵌套：相对目录路径（/ 分隔）
+    expect(slugs).toContain('pi-agent/01')
+    // 根层：文件名（现状零回归）
+    expect(slugs).toContain('hello-world')
+    expect(slugs).toContain('prerendered-blog-with-vite')
+    // 任何 slug 都不含 .md 后缀
+    for (const slug of slugs) {
+      expect(slug.endsWith('.md')).toBe(false)
+    }
+  })
+
+  it('recurses to arbitrary depth with /-separated slugs', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'posts-'))
+    try {
+      mkdirSync(join(dir, 'a', 'b', 'c'), { recursive: true })
+      writeFileSync(join(dir, 'a', 'root.md'), '# r')
+      writeFileSync(join(dir, 'a', 'b', 'c', 'deep.md'), '# d')
+
+      const slugs = collectPostSources(dir)
+        .map((source) => source.slug)
+        .sort()
+      expect(slugs).toEqual(['a/b/c/deep', 'a/root'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('loadPosts: recursive aggregation pipeline', () => {
+  it('aggregates nested posts with directory slugs and keeps global date-desc order', async () => {
+    const posts = await loadPosts(collectPostSources(POSTS_DIR))
+
+    const nested = posts.find((post) => post.slug === 'pi-agent/01')
+    expect(nested).toBeDefined()
+    expect(nested?.title).toBe('什么是 pi agent')
+    expect(nested?.date).toBe('2026-08-12')
+
+    // 嵌套文章参与全局日期倒序（首页平铺契约）
+    for (let i = 1; i < posts.length; i++) {
+      const prev = posts[i - 1]
+      const current = posts[i]
+      if (prev && current) {
+        expect(prev.date >= current.date).toBe(true)
+      }
+    }
+  })
+})

--- a/vite-posts-plugin.ts
+++ b/vite-posts-plugin.ts
@@ -1,9 +1,9 @@
 import type { Post } from './src/content/types.ts'
 import type { Plugin } from 'vite'
 
-import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { collectMarkdownFiles, collectPostSources } from './src/content/collectSources.ts'
 import { loadPosts } from './src/content/loadPosts.ts'
 
 const VIRTUAL_ID = 'virtual:posts'
@@ -11,13 +11,8 @@ const RESOLVED_ID = '\0' + VIRTUAL_ID
 const POSTS_DIR = join(process.cwd(), 'content', 'posts')
 
 function collectPosts(includeDrafts: boolean): Promise<Post[]> {
-  const sources = readdirSync(POSTS_DIR)
-    .filter((file) => file.endsWith('.md'))
-    .map((file) => ({
-      slug: file.replace(/\.md$/, ''),
-      raw: readFileSync(join(POSTS_DIR, file), 'utf8'),
-    }))
-  return loadPosts(sources, { includeDrafts })
+  // 递归聚合：嵌套目录文章的 slug = 相对目录路径（如 pi-agent/01）
+  return loadPosts(collectPostSources(POSTS_DIR), { includeDrafts })
 }
 
 /**
@@ -39,11 +34,9 @@ export function postsPlugin(): Plugin {
     },
     async load(id) {
       if (id !== RESOLVED_ID) return
-      // 仅监听 .md 文件（目录本身不参与 import 分析，避免 vitest 误解析）
-      for (const file of readdirSync(POSTS_DIR)) {
-        if (file.endsWith('.md')) {
-          this.addWatchFile(join(POSTS_DIR, file))
-        }
+      // 递归监听全部 .md 文件（含嵌套目录；目录本身不参与 import 分析，避免 vitest 误解析）
+      for (const file of collectMarkdownFiles(POSTS_DIR)) {
+        this.addWatchFile(file)
       }
       const code = `export default ${JSON.stringify(await collectPosts(includeDrafts))}`
       return code


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

Issue #41 完成：内容管线改为递归扫描（slug = 相对目录路径）、路由改 posts/* splat、预渲染/SEO 全部由 slug 推导，补全 pi-agent/01.md frontmatter；e2e 期望值收敛为共享 helper 并新增 4 条嵌套文章用例，单测 +31、e2e 69 全绿，已提交 f17e6fc（Ralph: issue-41）。

Closes #41