### PR TITLE
fix: issue #42 终端状态栏扩展：站点版本 + 当前主题 + git 状态

### DIFF
--- a/src/components/HeroTerminal.tsx
+++ b/src/components/HeroTerminal.tsx
@@ -1,4 +1,8 @@
 import { type CSSProperties, type ReactNode } from 'react'
+import siteMeta from 'virtual:site-meta'
+
+import { formatGitStats } from '../statusBar.ts'
+import { useTheme } from '../useTheme.ts'
 
 /**
  * hero 终端（issue #18，父 PRD #16）：pi.dev 风格 AI agent 会话演出。
@@ -17,6 +21,11 @@ import { type CSSProperties, type ReactNode } from 'react'
  *   （预渲染 HTML 含全文、SEO 不回归、无 hydration mismatch），
  *   prefers-reduced-motion 时 media query 整体禁用动画（含 live 点静止）、
  *   全文直接可见，无 JS 报错
+ * - 底部 caption 扩展为终端状态栏（issue #42）：在「● live」基础上追加三段真实信息——
+ *   站点版本（构建期注入 package.json version，v<version>）、当前主题（运行时状态，
+ *   theme: light/dark，SSR 输出确定性值 + 水合后更新为实际主题，无 mismatch）、
+ *   git 状态（构建期注入真实仓库统计 branch@sha · N commits，脏工作区分支后缀 *；
+ *   git 不可得时该段优雅省略，构建与发布不受阻）
  */
 
 /** 打字机参数：每字符耗时（总时长由文本长度驱动） */
@@ -98,8 +107,11 @@ function TurnRow({ turn, index }: { turn: TerminalTurn; index: number }) {
   )
 }
 
-/** hero 终端（pi.dev 风格）：四角括号 + 会话轮次 + 底部 live caption */
+/** hero 终端（pi.dev 风格）：四角括号 + 会话轮次 + 底部状态栏 */
 export default function HeroTerminal({ turns }: { turns: TerminalTurn[] }) {
+  // 当前主题：SSR/水合首帧输出确定性值 'light'，水合后更新为实际主题（无 mismatch）
+  const theme = useTheme()
+
   return (
     <div className="hero-terminal" role="group" aria-label="AI 会话演出">
       {/* 四角括号装饰（┌ ┐ └ ┘，绝对定位不占文档流，不进可访问性树） */}
@@ -116,10 +128,42 @@ export default function HeroTerminal({ turns }: { turns: TerminalTurn[] }) {
           ))}
         </div>
       </div>
-      {/* 底部 caption：● live 红点 + 弱化 mono 文字（可见文本精简为「live」） */}
-      <div className="hero-terminal-caption">
+      {/* 底部状态栏（issue #42）：● live · v<版本> · theme: <亮/暗> · git: <真实仓库统计>；
+          git 不可得时该段省略（role=status：主题切换时读屏播报更新） */}
+      <div className="hero-terminal-caption" role="status" aria-label="终端状态栏">
         <span className="live-dot" aria-hidden="true" />
-        <span>live</span>
+        <span className="status-item">live</span>
+        <span className="status-sep" aria-hidden="true">
+          ·
+        </span>
+        {/* 站点版本：构建期注入 package.json version */}
+        <span className="status-item" data-version={siteMeta.version}>
+          v{siteMeta.version}
+        </span>
+        <span className="status-sep" aria-hidden="true">
+          ·
+        </span>
+        {/* 当前主题：运行时状态（data-theme 供 e2e 断言） */}
+        <span className="status-item" data-theme={theme}>
+          theme: {theme}
+        </span>
+        {/* git 状态：构建期注入真实仓库统计；不可得时整段省略 */}
+        {siteMeta.git && (
+          <>
+            <span className="status-sep" aria-hidden="true">
+              ·
+            </span>
+            <span
+              className="status-item"
+              data-git-branch={siteMeta.git.branch}
+              data-git-sha={siteMeta.git.sha}
+              data-git-count={siteMeta.git.commitCount}
+              data-git-dirty={String(siteMeta.git.dirty)}
+            >
+              git: {formatGitStats(siteMeta.git)}
+            </span>
+          </>
+        )}
       </div>
       <span className="hero-terminal-corner hero-terminal-corner--bl" aria-hidden="true">
         └

--- a/src/index.css
+++ b/src/index.css
@@ -342,16 +342,21 @@ html.dark .bg-texture {
   }
 }
 
-/* 底部 caption：● live 红点 + 弱化 mono 文字（与正文以细线分隔）；
-   可见文本精简为「live」——去掉演出说明（issue #24） */
+/* 底部状态栏（issue #42）：● live · v<版本> · theme: <亮/暗> · git: <真实仓库统计>；
+   弱化 mono 文字（与正文以细线分隔）、段间以「·」分隔，多段在窄屏换行不撑破小屏 */
 .hero-terminal-caption {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.5rem;
   padding: 0.5rem 1rem 0.75rem;
   border-top: 1px solid #2b2b2b;
   font-size: 0.75rem;
   color: #8c8c8c;
+}
+.status-sep {
+  color: #555;
+  user-select: none;
 }
 .live-dot {
   flex-shrink: 0;

--- a/src/siteMeta.ts
+++ b/src/siteMeta.ts
@@ -1,0 +1,71 @@
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * 构建期站点元数据收集（issue #42）：package.json 版本号 + 真实仓库 git 统计。
+ * 仅 Node 侧（vite 插件 / 单测）导入——child_process / fs 不能进浏览器包，
+ * 浏览器侧经 virtual:site-meta 拿到注入后的 JSON（见 vite-site-meta-plugin.ts）。
+ */
+
+/** 真实仓库统计（构建期注入；git 不可得时为 null，状态栏优雅省略该段） */
+export interface GitStats {
+  /** 分支名（CI 分离头指针时为 HEAD） */
+  branch: string
+  /** 短 SHA */
+  sha: string
+  /** 提交数（git rev-list --count HEAD） */
+  commitCount: number
+  /** 工作区是否有未提交改动（git status --porcelain 非空） */
+  dirty: boolean
+}
+
+/** 构建期注入的站点元数据（virtual:site-meta） */
+export interface SiteMeta {
+  /** package.json version（读取失败回退 0.0.0，不阻塞构建） */
+  version: string
+  /** git 统计；不可得（CI 浅克隆 / 非 git 目录 / git 未安装）时为 null */
+  git: GitStats | null
+}
+
+/** git 可用性探测：非 git 目录 / git 缺失 → false（不抛错） */
+function isGitWorkTree(exec: typeof execSync): boolean {
+  try {
+    return exec('git rev-parse --is-inside-work-tree').toString().trim() === 'true'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 收集真实仓库统计：分支名 + 短 SHA + 提交数 + 脏标记。
+ * exec 可注入（单测模拟 git 缺失 / 浅克隆 / 非 git 目录等不可得场景）；
+ * 任何一步失败或结果不可用 → 返回 null（状态栏省略该段，构建与发布不受阻）。
+ */
+export function collectGitStats(exec: typeof execSync = execSync): GitStats | null {
+  if (!isGitWorkTree(exec)) return null
+  try {
+    const branch = exec('git rev-parse --abbrev-ref HEAD').toString().trim()
+    const sha = exec('git rev-parse --short HEAD').toString().trim()
+    const commitCount = Number.parseInt(exec('git rev-list --count HEAD').toString().trim(), 10)
+    const dirty = exec('git status --porcelain').toString().trim().length > 0
+    if (!branch || !sha || !Number.isFinite(commitCount)) return null
+    return { branch, sha, commitCount, dirty }
+  } catch {
+    return null
+  }
+}
+
+/** 站点版本：构建期读取 package.json（版本缺失/损坏回退 0.0.0） */
+export function collectSiteMeta(): SiteMeta {
+  let version = '0.0.0'
+  try {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as {
+      version?: unknown
+    }
+    if (typeof pkg.version === 'string' && pkg.version) version = pkg.version
+  } catch {
+    /* package.json 缺失/损坏：回退 0.0.0，不阻塞构建 */
+  }
+  return { version, git: collectGitStats() }
+}

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,0 +1,11 @@
+import type { GitStats } from './siteMeta.ts'
+
+/**
+ * git 状态段展示形态（终端状态栏，issue #42）：
+ * `branch@shortsha · N commits`；工作区有未提交改动时分支名后缀 `*`（bash PS1 惯例）。
+ * 客户端渲染用纯函数（浏览器安全：仅类型导入 siteMeta）；e2e 期望值从真实仓库
+ * 按同一契约计算（tests/e2e/git-helper.ts）。
+ */
+export function formatGitStats(git: GitStats): string {
+  return `${git.branch}${git.dirty ? '*' : ''}@${git.sha} · ${git.commitCount} commits`
+}

--- a/src/useTheme.ts
+++ b/src/useTheme.ts
@@ -1,0 +1,26 @@
+import { useSyncExternalStore } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+/** 客户端主题快照：<html> 的 .dark class（主题状态单一来源） */
+function readTheme(): Theme {
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+}
+
+/** 订阅主题变化：MutationObserver 监听 html class（ThemeToggle / 防闪烁脚本都改它） */
+function subscribeTheme(onStoreChange: () => void): () => void {
+  const observer = new MutationObserver(onStoreChange)
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+  return () => observer.disconnect()
+}
+
+/**
+ * 当前主题（亮/暗，运行时状态，issue #42）。
+ * SSR 安全（无 hydration mismatch）：getServerSnapshot 恒返回确定性值 'light'——
+ * SSR 与 hydration 首帧输出一致；水合完成后 React 切换到客户端快照（实际主题：
+ * localStorage 偏好 / 系统偏好 / 用户切换），即「SSR 输出确定性值、水合后更新为
+ * 实际主题」。切换主题（html class 变化）即时触发订阅更新。
+ */
+export function useTheme(): Theme {
+  return useSyncExternalStore(subscribeTheme, readTheme, () => 'light')
+}

--- a/src/virtual.d.ts
+++ b/src/virtual.d.ts
@@ -4,3 +4,10 @@ declare module 'virtual:posts' {
   const posts: Post[]
   export default posts
 }
+
+declare module 'virtual:site-meta' {
+  import type { SiteMeta } from './siteMeta.ts'
+
+  const meta: SiteMeta
+  export default meta
+}

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 import { readFileSync } from 'node:fs'
 
+import { currentGitStats } from './git-helper.ts'
 import { publishedPosts } from './posts-helper.ts'
 
 test('hero: big h1 site name + AI agent conversation (three Q&A rounds)', async ({ page }) => {
@@ -76,7 +77,7 @@ test('hero terminal: always black background with white text in light and dark t
   await expect(terminal).toHaveCSS('color', 'rgb(255, 255, 255)')
 })
 
-test('hero terminal: four corner brackets + bottom live caption (red dot, weak mono text)', async ({
+test('hero terminal: four corner brackets + bottom status bar (red live dot, weak mono text) (issue #42)', async ({
   page,
 }) => {
   await page.goto('/')
@@ -87,11 +88,10 @@ test('hero terminal: four corner brackets + bottom live caption (red dot, weak m
   await expect(corners).toHaveCount(4)
   expect((await corners.allTextContents()).sort()).toEqual(['┌', '┐', '└', '┘'].sort())
 
-  // 底部 caption：● live 红点 + 弱化 mono 文字（与正文以细线分隔）；
-  // 可见文本精简为「live」（去掉演出说明「AI 会话演出 · 自动播放一遍后停驻」）
+  // 底部 caption = 终端状态栏（issue #42）：● live · v<版本> · theme · git
   const caption = terminal.locator('.hero-terminal-caption')
   await expect(caption).toBeVisible()
-  await expect(caption).toHaveText('live', { useInnerText: true })
+  await expect(caption.getByText('live', { exact: true })).toBeVisible()
   await expect(caption.getByText('AI 会话演出')).toHaveCount(0)
   await expect(caption.getByText('自动播放一遍后停驻')).toHaveCount(0)
   expect(await caption.evaluate((el) => getComputedStyle(el).fontFamily)).toContain(
@@ -103,8 +103,111 @@ test('hero terminal: four corner brackets + bottom live caption (red dot, weak m
   await expect(dot).toBeVisible()
   expect(await dot.evaluate((el) => getComputedStyle(el).backgroundColor)).toBe('rgb(239, 68, 68)')
 
+  // 状态段三段真实信息各自存在（内容由专门用例从源计算断言）：版本 / 主题 / git
+  await expect(caption.locator('.status-item').filter({ hasText: /^v\d/ })).toBeVisible()
+  await expect(caption.locator('[data-theme]')).toBeVisible()
+  await expect(caption.locator('[data-git-branch]')).toBeVisible()
+
   // 无 mac 装饰圆点窗口栏（issue #18 移除；文章卡片的 ●●● 标题栏不受影响）
   await expect(terminal.locator('.hero-terminal-bar')).toHaveCount(0)
+})
+
+test('status bar: site version injected from package.json at build time (issue #42)', async ({
+  page,
+  request,
+}) => {
+  // 期望值从内容源计算模式延续：版本号从 package.json 读取（构建期注入的同一来源）
+  const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8')) as {
+    version: string
+  }
+  const expected = `v${pkg.version}`
+
+  await page.goto('/')
+  const versionItem = page
+    .locator('.hero-terminal-caption .status-item')
+    .filter({ hasText: expected })
+  await expect(versionItem).toBeVisible()
+  await expect(versionItem).toHaveAttribute('data-version', pkg.version)
+
+  // 构建期注入 → 预渲染 HTML 已含版本（爬虫不执行 JS 可读，SEO 不回归）；
+  // 注：React SSR 在混合静态文本与表达式的节点间插入 <!-- -->，先剥离再断言
+  const html = (await (await request.get('/')).text()).replaceAll('<!-- -->', '')
+  expect(html).toContain(expected)
+})
+
+test('status bar: theme segment updates instantly when toggling (issue #42)', async ({ page }) => {
+  await page.goto('/')
+  const themeItem = page.locator('.hero-terminal-caption [data-theme]')
+  await expect(themeItem).toBeVisible()
+
+  // 归一化亮色（初始主题由环境决定，先切到已知状态）
+  if ((await themeItem.getAttribute('data-theme')) === 'dark') {
+    await page.getByRole('button', { name: '切换暗色模式' }).click()
+  }
+  await expect(themeItem).toHaveAttribute('data-theme', 'light')
+  await expect(themeItem).toHaveText('theme: light')
+
+  // 切换主题 → 状态栏即时更新（MutationObserver 监听 html class，无需刷新）
+  await page.getByRole('button', { name: '切换暗色模式' }).click()
+  await expect(themeItem).toHaveAttribute('data-theme', 'dark')
+  await expect(themeItem).toHaveText('theme: dark')
+
+  await page.getByRole('button', { name: '切换暗色模式' }).click()
+  await expect(themeItem).toHaveText('theme: light')
+})
+
+test('status bar: SSR ships deterministic theme value, hydrates to actual theme without mismatch (issue #42)', async ({
+  page,
+  request,
+}) => {
+  const consoleErrors: string[] = []
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text())
+  })
+  page.on('pageerror', (err) => consoleErrors.push(err.message))
+
+  // SSR 确定性输出 'light'（与 hydration 首帧一致 → 无 mismatch）；
+  // 先剥离 React SSR 的 <!-- --> 注释分隔符再断言
+  const html = (await (await request.get('/')).text()).replaceAll('<!-- -->', '')
+  expect(html).toContain('theme: light')
+
+  // 暗色偏好：首帧前 inline 防闪烁脚本置 .dark → 水合后状态栏更新为实际主题 dark
+  await page.addInitScript(() => localStorage.setItem('theme', 'dark'))
+  await page.goto('/')
+  const themeItem = page.locator('.hero-terminal-caption [data-theme]')
+  await expect(themeItem).toHaveText('theme: dark')
+
+  // 全程无 hydration/mismatch 报错（React 对 useSyncExternalStore 用服务端快照水合）
+  expect(consoleErrors.filter((e) => /hydrat|mismatch/i.test(e))).toHaveLength(0)
+})
+
+test('status bar: git stats computed from the real repository (issue #42)', async ({
+  page,
+  request,
+}) => {
+  // 期望值从真实仓库计算（与构建期注入同一契约：分支 / 短 SHA / 提交数 / 脏标记）
+  const git = currentGitStats()
+  test.skip(!git, '非 git 目录：git 段优雅省略（省略逻辑由单测覆盖）')
+
+  await page.goto('/')
+  const gitItem = page.locator('.hero-terminal-caption [data-git-branch]')
+  await expect(gitItem).toBeVisible()
+  await expect(gitItem).toHaveAttribute('data-git-branch', git?.branch ?? '')
+  await expect(gitItem).toHaveAttribute('data-git-sha', git?.sha ?? '')
+  await expect(gitItem).toHaveAttribute('data-git-count', String(git?.commitCount))
+  await expect(gitItem).toHaveAttribute('data-git-dirty', String(git?.dirty))
+
+  // 展示形态：git: branch[@dirty]@shortsha · N commits（与 formatGitStats 同一契约）
+  const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const branch = esc(git?.branch ?? '')
+  await expect(gitItem).toHaveText(
+    new RegExp(`^git: ${branch}\\*?@${git?.sha} · ${git?.commitCount} commits$`),
+  )
+
+  // 构建期注入 → 预渲染 HTML 已含 git 段（爬虫不执行 JS 可读）；先剥离 SSR 注释分隔符；
+  // 脏工作区分支带 * 后缀（与 formatGitStats 同一契约）
+  const html = (await (await request.get('/')).text()).replaceAll('<!-- -->', '')
+  expect(html).toContain(`git: ${git?.branch}${git?.dirty ? '*' : ''}@${git?.sha}`)
 })
 
 test('prerendered HTML contains the full conversation text (SEO no regression)', async ({
@@ -126,6 +229,12 @@ test('prerendered HTML contains the full conversation text (SEO no regression)',
   expect(html).toContain('了解真相，才能获得真正的自由')
   expect(html).toContain('https://github.com/hacxy')
   expect(html).toContain('live')
+  // 状态栏（issue #42）构建期注入/确定性值同样在预渲染源码中：版本 + theme: light
+  const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8')) as {
+    version: string
+  }
+  expect(html).toContain(`v${pkg.version}`)
+  expect(html).toContain('theme: light')
 })
 
 test('hero terminal: CSS show plays once and stops; live dot pulses infinitely', async ({

--- a/tests/e2e/git-helper.ts
+++ b/tests/e2e/git-helper.ts
@@ -1,0 +1,28 @@
+import { execSync } from 'node:child_process'
+
+export interface ExpectedGitStats {
+  branch: string
+  sha: string
+  commitCount: number
+  dirty: boolean
+}
+
+/**
+ * 期望 git 统计：从真实仓库计算（issue #42 验收「git 期望值从真实仓库计算」，
+ * 与构建期注入同一契约：分支 / 短 SHA / 提交数 / 工作区脏标记）。
+ * git 不可得（非 git 目录 / CI 浅克隆 / git 未安装）时返回 null——
+ * 状态栏该段优雅省略，e2e 相应跳过（省略逻辑本身由单测覆盖）。
+ */
+export function currentGitStats(): ExpectedGitStats | null {
+  try {
+    const inside = execSync('git rev-parse --is-inside-work-tree').toString().trim()
+    if (inside !== 'true') return null
+    const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
+    const sha = execSync('git rev-parse --short HEAD').toString().trim()
+    const commitCount = Number.parseInt(execSync('git rev-list --count HEAD').toString().trim(), 10)
+    const dirty = execSync('git status --porcelain').toString().trim().length > 0
+    return { branch, sha, commitCount, dirty }
+  } catch {
+    return null
+  }
+}

--- a/tests/unit/site-meta.test.ts
+++ b/tests/unit/site-meta.test.ts
@@ -1,0 +1,78 @@
+import { execSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+import { collectGitStats, collectSiteMeta } from '../../src/siteMeta.ts'
+import { formatGitStats } from '../../src/statusBar.ts'
+
+/**
+ * issue #42：终端状态栏构建期元数据——站点版本（package.json）与 git 统计
+ * （真实仓库）的收集与展示形态。git 不可得（CI 浅克隆 / 非 git 目录 / git 未安装）
+ * 时优雅返回 null（状态栏省略该段、构建不失败）——用可注入 exec 模拟。
+ */
+
+/** 模拟 exec：is-inside-work-tree 之外全部失败（如浅克隆缺 rev-list） */
+function fakeExec(inside: boolean, failOther: boolean): typeof execSync {
+  return ((cmd: string) => {
+    if (cmd.includes('is-inside-work-tree')) {
+      return { toString: () => String(inside) } as never
+    }
+    if (failOther) throw new Error('git: 命令失败（浅克隆 / CI）')
+    return { toString: () => 'main\n2fe73c3\n211\n' } as never
+  }) as unknown as typeof execSync
+}
+
+describe('collectGitStats', () => {
+  it('collects real repository stats in a git work tree', () => {
+    const git = collectGitStats()
+    expect(git).not.toBeNull()
+    expect(git?.branch.length).toBeGreaterThan(0)
+    expect(git?.sha).toMatch(/^[0-9a-f]+$/)
+    expect(git?.sha.length).toBeGreaterThanOrEqual(7)
+    expect(git?.commitCount).toBeGreaterThan(0)
+    expect(typeof git?.dirty).toBe('boolean')
+  })
+
+  it('returns null outside a git work tree (非 git 目录)', () => {
+    expect(collectGitStats(fakeExec(false, false))).toBeNull()
+  })
+
+  it('returns null when any stat command fails (CI 浅克隆 / git 缺失)', () => {
+    expect(collectGitStats(fakeExec(true, true))).toBeNull()
+    // git 命令整体抛错（git 未安装）
+    const throwing = (() => {
+      throw new Error('git: command not found')
+    }) as unknown as typeof execSync
+    expect(collectGitStats(throwing)).toBeNull()
+  })
+
+  it('returns null when parsed stats are unusable', () => {
+    // 分支名 / SHA 为空或提交数非有限数 → 视为不可得
+    const empty = ((cmd: string) => {
+      if (cmd.includes('is-inside-work-tree')) return { toString: () => 'true' } as never
+      return { toString: () => '\n\nabc\n' } as never
+    }) as unknown as typeof execSync
+    expect(collectGitStats(empty)).toBeNull()
+  })
+})
+
+describe('collectSiteMeta', () => {
+  it('reads the version from package.json and attaches git stats', () => {
+    const meta = collectSiteMeta()
+    expect(meta.version).toMatch(/^\d+\.\d+\.\d+/)
+    expect(meta.git).not.toBeNull()
+  })
+})
+
+describe('formatGitStats（状态栏展示形态：branch@sha · N commits，脏工作区分支后缀 *）', () => {
+  it('formats branch@shortsha with commit count', () => {
+    expect(formatGitStats({ branch: 'main', sha: '2fe73c3', commitCount: 211, dirty: false })).toBe(
+      'main@2fe73c3 · 211 commits',
+    )
+  })
+
+  it('appends an asterisk to the branch when the working tree is dirty', () => {
+    expect(formatGitStats({ branch: 'agent/x', sha: 'abc1234', commitCount: 5, dirty: true })).toBe(
+      'agent/x*@abc1234 · 5 commits',
+    )
+  })
+})

--- a/vite-site-meta-plugin.ts
+++ b/vite-site-meta-plugin.ts
@@ -1,0 +1,25 @@
+import type { Plugin } from 'vite'
+
+import { collectSiteMeta } from './src/siteMeta.ts'
+
+const VIRTUAL_ID = 'virtual:site-meta'
+const RESOLVED_ID = '\0' + VIRTUAL_ID
+
+/**
+ * 构建期站点元数据注入（issue #42）：package.json 版本号 + 真实仓库 git 统计。
+ * 与 postsPlugin 同一模式——Node 侧收集（child_process / fs 不能进浏览器包），
+ * 注入 virtual:site-meta 供客户端与 SSR 共享；git 不可得（CI 浅克隆 / 非 git 目录 /
+ * git 未安装）时 collectSiteMeta 返回 null，状态栏优雅省略该段、构建不失败。
+ */
+export function siteMetaPlugin(): Plugin {
+  return {
+    name: 'site-meta-manifest',
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_ID
+    },
+    load(id) {
+      if (id !== RESOLVED_ID) return
+      return `export default ${JSON.stringify(collectSiteMeta())}`
+    },
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,10 @@ import { defineConfig } from 'vitest/config'
 
 import { postAssetsPlugin } from './vite-assets-plugin.ts'
 import { postsPlugin } from './vite-posts-plugin.ts'
+import { siteMetaPlugin } from './vite-site-meta-plugin.ts'
 
 export default defineConfig({
-  plugins: [react(), tailwindcss(), postsPlugin(), postAssetsPlugin()],
+  plugins: [react(), tailwindcss(), postsPlugin(), postAssetsPlugin(), siteMetaPlugin()],
   test: {
     environment: 'jsdom',
     include: ['tests/unit/**/*.test.{ts,tsx}'],


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

完成 issue #42：终端状态栏在 ● live 基础上扩展站点版本（构建期注入 package.json）、当前主题（useSyncExternalStore SSR 确定性值 + 水合后更新，无 mismatch、切换即时响应）、git 状态（构建期注入真实仓库统计，不可得时优雅省略）；新增 siteMetaPlugin/virtual:site-meta 与 7 单测 + 4 e2e（期望值从 package.json/真实仓库计算），typecheck/lint/38 单测/73 e2e 全量通过，已提交 386bc3d（Ralph: issue-42）

Closes #42