### PR TITLE
fix: issue #44 文章页左栏层级树（派生 + 组件 + 移动端复用）

### DIFF
--- a/src/components/PostIndex.tsx
+++ b/src/components/PostIndex.tsx
@@ -1,38 +1,18 @@
-import { NavLink } from 'react-router'
-
-import { posts } from '../content/index.ts'
-
-/** 索引行类名：行形态复用首页终端行（.post-row），当前文章追加 nav-active——
- *  全站导航高亮机制（加粗 + 下划线，见 index.css .post-index a.nav-active，
- *  与顶部导航 .site-nav a.nav-active 同一令牌） */
-const indexLinkClass = ({ isActive }: { isActive: boolean }) =>
-  `post-row${isActive ? ' nav-active' : ''}`
+import PostTree from './PostTree.tsx'
 
 /**
- * 文章页左栏文章索引（issue #29）：sticky 常驻全部文章列表，
- * 与首页终端行同构（mono 日期 + 标题，日期倒序由内容清单保证），
- * 当前文章加粗 + 下划线高亮（NavLink 自动注入 aria-current="page"）。
- * <768px 由 CSS 隐藏（抽屉交互由后续工单接入），仅渲染于文章页。
+ * 文章页左栏文章索引（issue #29 + issue #44）：sticky 常驻完整层级树——
+ * 根层文章 + 各级文件夹（可折叠抽屉），由内容清单平铺列表派生（同一来源，
+ * 见 content/tree.ts）；当前文章所在分支自动展开至所在层，当前文章加粗 +
+ * 下划线高亮（NavLink 自动注入 aria-current="page"）。
+ * 桌面侧栏与移动端覆盖式抽屉复用同一组件（PostDrawerNav 的「文章」抽屉内容
+ * 即本组件，行为与桌面一致）；<768px 由 CSS 隐藏（抽屉交互见 issue #31），
+ * 仅渲染于文章页。首页列表保持平铺形态（PostRow，不受影响）。
  */
 export default function PostIndex() {
   return (
     <nav aria-label="文章索引" className="post-index">
-      <ul className="post-row-list">
-        {posts.map((post) => (
-          <li key={post.slug}>
-            <NavLink to={`/posts/${post.slug}`} className={indexLinkClass}>
-              {/* 行首终端提示符：装饰性（aria-hidden），与首页终端行同构（hover/focus 淡入） */}
-              <span className="post-row-prompt" aria-hidden="true">
-                &gt;
-              </span>
-              <time dateTime={post.date} className="post-row-date">
-                {post.date}
-              </time>
-              <span className="post-row-title">{post.title}</span>
-            </NavLink>
-          </li>
-        ))}
-      </ul>
+      <PostTree />
     </nav>
   )
 }

--- a/src/components/PostTree.tsx
+++ b/src/components/PostTree.tsx
@@ -1,0 +1,115 @@
+import type { TreeNode } from '../content/tree.ts'
+
+import { useMemo, useState } from 'react'
+import { NavLink, useParams } from 'react-router'
+
+import { posts } from '../content/index.ts'
+import { ancestorPaths, buildPostTree } from '../content/tree.ts'
+
+/**
+ * 文章页左栏层级树（issue #44）：根层文章 + 各级文件夹（可折叠抽屉）。
+ * 树由内容清单平铺列表派生（buildPostTree，同一来源）；桌面侧栏与移动端
+ * 覆盖式抽屉复用同一组件（PostIndex 包裹，<768px「文章」按钮抽屉内容相同）。
+ *
+ * 行为契约：
+ * - 当前文章所在分支自动展开至所在层（挂载与客户端导航时按祖先文件夹路径补充）；
+ * - 子文件夹为可折叠抽屉：按钮 aria-expanded 标记可见状态，点击展开/收起；
+ * - 同层内文件夹字母序在前、文章日期倒序在后（递归同规则，由 buildPostTree 保证）；
+ * - 当前文章沿用全站 nav-active 高亮（加粗 + 下划线，NavLink 自动注入
+ *   aria-current="page"）。
+ */
+
+/** 构建期一次派生：树 = 清单之上的派生结构（同一来源，纯函数、确定性） */
+const TREE = buildPostTree(posts)
+
+/** 索引行类名：行形态复用首页终端行（.post-row），当前文章追加 nav-active——
+ *  全站导航高亮机制（加粗 + 下划线，见 index.css .post-index a.nav-active，
+ *  与顶部导航 .site-nav a.nav-active 同一令牌） */
+const indexLinkClass = ({ isActive }: { isActive: boolean }) =>
+  `post-row${isActive ? ' nav-active' : ''}`
+
+export default function PostTree() {
+  const slug = useParams()['*'] ?? ''
+  // 当前文章所在分支：祖先文件夹路径（根层文章为空 → 无自动展开）
+  const ancestors = useMemo(() => ancestorPaths(slug), [slug])
+  // 折叠状态：以目录路径为键；初始即含当前分支（SSR 首帧与 hydration 一致）
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(ancestors))
+
+  // 客户端导航（树内点击 / 浏览器前进后退切换文章）时保持手动展开状态，
+  // 并把新文章的祖先文件夹补充展开——「调整 state 以响应 prop 变化」的
+  // React 惯用法（渲染期条件更新，非 effect，官方推荐替代 effect 的方案）
+  const [prevSlug, setPrevSlug] = useState(slug)
+  if (slug !== prevSlug) {
+    setPrevSlug(slug)
+    setExpanded((prev) => {
+      if (ancestors.every((path) => prev.has(path))) return prev
+      const next = new Set(prev)
+      for (const path of ancestors) next.add(path)
+      return next
+    })
+  }
+
+  const toggle = (path: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+
+  return <TreeBranch nodes={TREE} expanded={expanded} onToggle={toggle} />
+}
+
+/** 递归渲染层级树的一层：文件夹（可折叠抽屉按钮）+ 文章（终端行 NavLink） */
+function TreeBranch({
+  nodes,
+  expanded,
+  onToggle,
+}: {
+  nodes: TreeNode[]
+  expanded: Set<string>
+  onToggle: (path: string) => void
+}) {
+  return (
+    <ul className="post-tree-list">
+      {nodes.map((node) =>
+        node.type === 'folder' ? (
+          <li key={`folder-${node.path}`}>
+            <button
+              type="button"
+              className="post-tree-folder"
+              aria-expanded={expanded.has(node.path)}
+              onClick={() => onToggle(node.path)}
+            >
+              {/* 折叠标记：装饰性（aria-hidden），▸ 收起 / ▾ 展开 */}
+              <span className="post-tree-folder-marker" aria-hidden="true">
+                {expanded.has(node.path) ? '▾' : '▸'}
+              </span>
+              <span className="post-tree-folder-name">{node.name}/</span>
+            </button>
+            {/* 收起时不渲染子级：不进可访问性树、不占 Tab 序（与抽屉条件挂载同一模式） */}
+            {expanded.has(node.path) && (
+              <TreeBranch nodes={node.children} expanded={expanded} onToggle={onToggle} />
+            )}
+          </li>
+        ) : (
+          <li key={`post-${node.post.slug}`}>
+            <NavLink to={`/posts/${node.post.slug}`} className={indexLinkClass}>
+              {/* 行首终端提示符：装饰性（aria-hidden），与首页终端行同构（hover/focus 淡入） */}
+              <span className="post-row-prompt" aria-hidden="true">
+                &gt;
+              </span>
+              <time dateTime={node.post.date} className="post-row-date">
+                {node.post.date}
+              </time>
+              <span className="post-row-title">{node.post.title}</span>
+            </NavLink>
+          </li>
+        ),
+      )}
+    </ul>
+  )
+}

--- a/src/content/tree.ts
+++ b/src/content/tree.ts
@@ -1,0 +1,98 @@
+import type { Post } from './types.ts'
+
+import { directoryOf } from './navigation.ts'
+
+/**
+ * 文章页左栏层级树（issue #44）：由内容清单（平铺列表）派生的纯数据结构。
+ * 树是清单之上的派生结构、同一来源——buildPostTree 不修改输入清单，
+ * 平铺契约（loadPosts 的日期倒序清单）不回归。
+ *
+ * 同层排序规则（递归同规则）：
+ * - 文件夹在前，按目录名字母序（code point 序，确定性）；
+ * - 文章在后，按日期倒序（date 降序，同日期保持输入清单的相对顺序——稳定排序）。
+ */
+
+/** 树节点：文件夹（可折叠抽屉） */
+export interface FolderTreeNode {
+  type: 'folder'
+  /** 目录相对路径（如 pi-agent 或 a/b），折叠状态以路径为键 */
+  path: string
+  /** 目录名（最后一段，展示用） */
+  name: string
+  children: TreeNode[]
+}
+
+/** 树节点：文章（终端行链接） */
+export interface PostTreeNode {
+  type: 'post'
+  post: Post
+}
+
+/** 层级树节点联合 */
+export type TreeNode = FolderTreeNode | PostTreeNode
+
+/**
+ * 从平铺内容清单派生层级树：根层 = 各级文件夹（字母序在前）+ 根层文章
+ * （日期倒序在后）；文件夹内递归同规则。目录任意深度嵌套（issue #41 的
+ * slug 契约：相对目录路径）。
+ */
+export function buildPostTree(posts: Post[]): TreeNode[] {
+  const root: TreeNode[] = []
+  // 目录路径 → 文件夹节点：插入时按路径复用，避免同目录文章重复建文件夹
+  const folders = new Map<string, FolderTreeNode>()
+
+  // 逐篇文章挂到其目录链的末端（保持输入顺序，排序在最后统一进行）
+  for (const post of posts) {
+    const parts = directoryOf(post.slug)
+    let children = root
+    let path = ''
+    for (const part of parts === '' ? [] : parts.split('/')) {
+      path = path === '' ? part : `${path}/${part}`
+      let folder = folders.get(path)
+      if (!folder) {
+        folder = { type: 'folder', path, name: part, children: [] }
+        folders.set(path, folder)
+        children.push(folder)
+      }
+      children = folder.children
+    }
+    children.push({ type: 'post', post })
+  }
+
+  // 同层排序（递归）：文件夹字母序在前、文章日期倒序在后
+  const sortLevel = (nodes: TreeNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.type === 'folder' && b.type === 'folder') {
+        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+      }
+      if (a.type === 'post' && b.type === 'post') {
+        return a.post.date < b.post.date ? 1 : a.post.date > b.post.date ? -1 : 0
+      }
+      return a.type === 'folder' ? -1 : 1
+    })
+    for (const node of nodes) {
+      if (node.type === 'folder') sortLevel(node.children)
+    }
+  }
+  sortLevel(root)
+
+  return root
+}
+
+/**
+ * slug → 其所在分支的全部祖先文件夹路径（含根到所在的每一层，按深度序）。
+ * 根层文章返回空数组（无文件夹可展开）；pi-agent/01 → ['pi-agent']；
+ * a/b/c/post → ['a', 'a/b', 'a/b/c']。组件以此在挂载/导航时
+ * 「自动展开至当前文章所在层」。
+ */
+export function ancestorPaths(slug: string): string[] {
+  const parts = slug.split('/')
+  parts.pop() // 去掉最后一段（文章 slug 自身）
+  const paths: string[] = []
+  let path = ''
+  for (const part of parts) {
+    path = path === '' ? part : `${path}/${part}`
+    paths.push(path)
+  }
+  return paths
+}

--- a/src/index.css
+++ b/src/index.css
@@ -603,6 +603,71 @@ html.dark .terminal-dot--green {
   text-decoration: underline;
 }
 
+/* ===== 文章页左栏层级树（issue #44）：根层文章 + 各级文件夹（可折叠抽屉） ===== */
+
+/* 树列表：与首页终端行列表同一布局（行间紧凑）；根列表无顶部留白（sticky 侧栏内） */
+.post-tree-list {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.post-index .post-tree-list {
+  margin-top: 0;
+}
+
+/* 嵌套子列表：缩进 + 树状参考线（层级视觉，暗色随 --prose-border 反色） */
+.post-tree-list .post-tree-list {
+  margin: 0.25rem 0 0.25rem 0.375rem;
+  padding-left: 0.875rem;
+  border-left: 1px solid var(--color-prose-border);
+}
+
+/* 文件夹行：按钮形态（非链接），行布局与 .post-row 同构（折叠标记 + mono 名）；
+   常规字重、muted 灰（结构层弱于文章标题），hover/键盘焦点 accent + 下划线，
+   背景不反白（与文章行同一豁免） */
+.post-tree-folder {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem 0.875rem;
+  width: 100%;
+  padding: 0.5rem 0.375rem;
+  border: none;
+  background: none;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-muted);
+  text-align: left;
+  cursor: pointer;
+}
+.post-tree-folder:hover,
+.post-tree-folder:focus-visible {
+  background-color: transparent;
+  color: var(--color-accent);
+}
+.post-tree-folder:hover .post-tree-folder-name,
+.post-tree-folder:focus-visible .post-tree-folder-name {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* 展开中的文件夹：加粗 + accent（可见状态与当前文章高亮同一节奏） */
+.post-tree-folder[aria-expanded='true'] {
+  font-weight: 700;
+  color: var(--color-accent);
+}
+
+/* 折叠标记：与 .post-row-prompt 同一槽位（1rem 宽、负 margin 抵消 gap）——
+   文件夹名与文章标题纵向对齐 */
+.post-tree-folder-marker {
+  flex: 0 0 1rem;
+  margin-right: -0.875rem;
+  font-size: 0.75rem;
+  color: var(--color-accent);
+}
+
 /* 中栏正文：自然收窄至 ~600px（37.5rem，中文 ~35 字/行）阅读宽度 */
 .post-main {
   max-width: 37.5rem;

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1623,11 +1623,14 @@ test('layout foundation: outer container widens to max-w-6xl; homepage/about con
   ).toBeCloseTo(600, 1)
 })
 
-test('post page left index: full list date desc, current highlighted, sticky, clickable; <768px single column (issue #29)', async ({
+test('post page left index: hierarchy tree — folders alpha first then posts date-desc, folders collapsible, current highlighted, sticky (issue #44)', async ({
   page,
 }) => {
   // 期望值：从内容源计算（与内容清单同一契约：非 draft、日期倒序）
   const published = publishedPosts()
+  const rootPosts = published.filter((post) => expectedDirectory(post.slug) === '')
+  const nestedPosts = published.filter((post) => expectedDirectory(post.slug) !== '')
+  const dirs = [...new Set(nestedPosts.map((post) => expectedDirectory(post.slug)))].sort()
 
   // ≥768px：两栏生效（1280px 视口下断言左栏索引）
   await page.setViewportSize({ width: 1280, height: 900 })
@@ -1636,16 +1639,27 @@ test('post page left index: full list date desc, current highlighted, sticky, cl
   const index = page.getByRole('navigation', { name: '文章索引' })
   await expect(index).toBeVisible()
 
-  // 全文章列表：数量与内容源一致
+  // 根层 = 文件夹（字母序）在前 + 根层文章（日期倒序）在后；当前文章为根层 →
+  // 无自动展开的文件夹（全部收起）
+  const folders = index.locator('.post-tree-folder')
+  await expect(folders).toHaveCount(dirs.length)
   const rows = index.locator('.post-row')
-  await expect(rows).toHaveCount(published.length)
+  await expect(rows).toHaveCount(rootPosts.length)
+  for (let i = 0; i < dirs.length; i++) {
+    await expect(folders.nth(i)).toHaveAttribute('aria-expanded', 'false')
+    await expect(folders.nth(i)).toContainText(`${dirs[i]}/`)
+  }
+  // 同层顺序：文件夹全部在文章之前（字母序在前）
+  const lastFolderBottom = await folders.last().evaluate((el) => el.getBoundingClientRect().bottom)
+  const firstRowTop = await rows.first().evaluate((el) => el.getBoundingClientRect().top)
+  expect(lastFolderBottom).toBeLessThanOrEqual(firstRowTop)
 
-  // 日期倒序：最新文章在最前
-  await expect(rows.first().locator('.post-row-date')).toHaveText(published[0]?.date ?? '')
-  await expect(rows.first().locator('.post-row-title')).toHaveText(published[0]?.title ?? '')
+  // 根层文章日期倒序：最新在最前
+  await expect(rows.first().locator('.post-row-date')).toHaveText(rootPosts[0]?.date ?? '')
+  await expect(rows.first().locator('.post-row-title')).toHaveText(rootPosts[0]?.title ?? '')
 
   // 每行 = mono 日期 + 标题（与首页终端行同构），指向对应文章页
-  for (const post of published) {
+  for (const post of rootPosts) {
     const row = rows.filter({ hasText: post.title })
     await expect(row).toHaveAttribute('href', `/posts/${post.slug}`)
     await expect(row.locator('.post-row-date')).toHaveText(post.date)
@@ -1667,6 +1681,28 @@ test('post page left index: full list date desc, current highlighted, sticky, cl
   expect(
     await rows.filter({ hasText: '第二篇文章' }).evaluate((el) => getComputedStyle(el).fontWeight),
   ).toBe('400')
+
+  // 子文件夹为可折叠抽屉：点击展开 → 嵌套文章（日期倒序）出现、aria-expanded 翻转；
+  // 再点收起 → 子级卸载（不进可访问性树、不占 Tab 序）
+  const folder = folders.first()
+  await folder.click()
+  await expect(folder).toHaveAttribute('aria-expanded', 'true')
+  await expect(index.locator('.post-row')).toHaveCount(published.length)
+  for (const post of nestedPosts) {
+    await expect(index.locator('.post-row').filter({ hasText: post.title })).toHaveAttribute(
+      'href',
+      `/posts/${post.slug}`,
+    )
+  }
+  // 同层规则递归：文件夹内文章日期倒序（最新在前）
+  const nestedRows = index.locator('.post-tree-list .post-tree-list .post-row')
+  await expect(nestedRows.first().locator('.post-row-date')).toHaveText(nestedPosts[0]?.date ?? '')
+  await expect(nestedRows.first().locator('.post-row-title')).toHaveText(
+    nestedPosts[0]?.title ?? '',
+  )
+  await folder.click()
+  await expect(folder).toHaveAttribute('aria-expanded', 'false')
+  await expect(index.locator('.post-row')).toHaveCount(rootPosts.length)
 
   // 左栏 sticky 跟随滚动：滚动到正文底部后索引仍固定在视口内（top = sticky 偏移）
   expect(await index.evaluate((el) => getComputedStyle(el).position)).toBe('sticky')
@@ -1690,6 +1726,46 @@ test('post page left index: full list date desc, current highlighted, sticky, cl
     () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
   )
   expect(overflow).toBe(false)
+})
+
+test('post page left index: current branch auto-expands to its level on mount and client navigation (issue #44)', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 })
+
+  // 直达嵌套文章（初始挂载）：当前分支自动展开至所在层，同层文章与子文件夹可见
+  await page.goto('/posts/pi-agent/01')
+  const index = page.getByRole('navigation', { name: '文章索引' })
+  await expect(index).toBeVisible()
+  const folder = index.getByRole('button', { name: /pi-agent\// })
+  await expect(folder).toHaveAttribute('aria-expanded', 'true')
+  await expect(folder).toContainText('pi-agent/')
+  // 折叠标记反映可见状态：展开 ▾（收起时为 ▸）
+  await expect(folder.locator('.post-tree-folder-marker')).toHaveText('▾')
+
+  // 当前文章高亮：nav-active（加粗 + 下划线）+ aria-current="page"
+  const current = index.getByRole('link', { name: /什么是 pi agent/ })
+  await expect(current).toHaveClass(/nav-active/)
+  await expect(current).toHaveAttribute('aria-current', 'page')
+  expect(await current.evaluate((el) => getComputedStyle(el).fontWeight)).toBe('700')
+  expect(await current.evaluate((el) => getComputedStyle(el).textDecorationLine)).toContain(
+    'underline',
+  )
+
+  // 同层文章（02）与根层文章同在树中；同层规则递归：文件夹内文章日期倒序（01 在 02 前）
+  await expect(index.getByRole('link', { name: /pi agent 运行原理/ })).toBeVisible()
+  await expect(index.getByRole('link', { name: /你好，世界/ })).toBeVisible()
+  const nestedRows = index.locator('.post-tree-list .post-tree-list .post-row')
+  await expect(nestedRows.first().locator('.post-row-title')).toHaveText('什么是 pi agent')
+  await expect(nestedRows.nth(1).locator('.post-row-title')).toHaveText('pi agent 运行原理')
+
+  // 客户端导航到根层文章：高亮跟随切换（分支保持用户展开状态），当前行在根层
+  await index.getByRole('link', { name: /你好，世界/ }).click()
+  await expect(page).toHaveURL(/\/posts\/hello-world/)
+  const hello = index.getByRole('link', { name: /你好，世界/ })
+  await expect(hello).toHaveClass(/nav-active/)
+  await expect(hello).toHaveAttribute('aria-current', 'page')
+  await expect(current).not.toHaveClass(/nav-active/)
 })
 
 /* ===== 移动端抽屉（issue #31）：窄屏侧栏收进覆盖式抽屉 ===== */
@@ -1749,11 +1825,12 @@ test('mobile drawer: <1024px 目录 button opens right TOC drawer with working s
   await expect(tocTrigger).toBeFocused()
 })
 
-test('mobile drawer: <768px 文章 button opens left index drawer; current article highlighted; row click navigates (issue #31)', async ({
+test('mobile drawer: <768px 文章 button opens left index drawer with the same hierarchy tree; current article highlighted (issue #44)', async ({
   page,
 }) => {
   // 期望值从内容源计算（与内容清单同一契约：非 draft 文章、日期倒序）
   const published = publishedPosts()
+  const rootPosts = published.filter((post) => expectedDirectory(post.slug) === '')
 
   await page.setViewportSize({ width: 600, height: 800 })
   await page.goto('/posts/prerendered-blog-with-vite')
@@ -1764,25 +1841,30 @@ test('mobile drawer: <768px 文章 button opens left index drawer; current artic
   await expect(indexTrigger).toBeVisible()
   await expect(page.getByRole('navigation', { name: '文章索引' })).toBeHidden()
 
-  // 点击「文章」→ 左侧抽屉滑出；内容复用桌面左栏组件（当前文章高亮 + aria-current）
+  // 点击「文章」→ 左侧抽屉滑出；内容复用桌面左栏组件（同一层级树，当前文章高亮 + aria-current）
   await indexTrigger.click()
   const dialog = page.getByRole('dialog', { name: '文章索引' })
   await expect(dialog).toBeVisible()
   const drawerIndex = dialog.getByRole('navigation', { name: '文章索引' })
   await expect(drawerIndex).toBeVisible()
+
+  // 抽屉内容 = 同一层级树：根层文件夹 + 根层文章（数量/顺序与内容源一致）
+  await expect(drawerIndex.locator('.post-tree-folder')).toHaveCount(1)
+  await expect(drawerIndex.locator('.post-row')).toHaveCount(rootPosts.length)
+  await expect(drawerIndex.locator('.post-row-date').first()).toHaveText(rootPosts[0]?.date ?? '')
+
   const current = drawerIndex.getByRole('link', {
     name: /用 React \+ Vite 搭一个构建期预渲染的静态博客/,
   })
   await expect(current).toHaveClass(/nav-active/)
   await expect(current).toHaveAttribute('aria-current', 'page')
 
-  // 抽屉内容与桌面侧栏一致：全文章列表（数量/顺序与内容源一致）+ mono 日期
+  // 抽屉内文件夹同样可折叠可展开（行为与桌面一致）：展开后嵌套文章出现、点击可跳转
+  await drawerIndex.locator('.post-tree-folder').click()
+  await expect(drawerIndex.locator('.post-tree-folder')).toHaveAttribute('aria-expanded', 'true')
   await expect(drawerIndex.locator('.post-row')).toHaveCount(published.length)
-  await expect(drawerIndex.locator('.post-row-date').first()).toHaveText(published[0]?.date ?? '')
-
-  // 点击抽屉内文章行 → 跳转对应文章页（抽屉随页面卸载）
-  await drawerIndex.getByRole('link', { name: '第二篇文章' }).click()
-  await expect(page).toHaveURL(/\/posts\/second-post/)
+  await drawerIndex.getByRole('link', { name: '什么是 pi agent' }).click()
+  await expect(page).toHaveURL(/\/posts\/pi-agent\/01/)
 })
 
 test('desktop ≥1024px: drawer buttons hidden (no Tab insertion), sidebars persistent (issue #31)', async ({
@@ -1800,7 +1882,7 @@ test('desktop ≥1024px: drawer buttons hidden (no Tab insertion), sidebars pers
   await expect(page.getByRole('navigation', { name: '文章索引' })).toBeVisible()
   await expect(page.getByRole('navigation', { name: '文章目录' })).toBeVisible()
 
-  // Tab 顺序无变化：文章 → 关于 → 主题 → GitHub → RSS → 左栏第一行（无抽屉按钮插队）
+  // Tab 顺序无变化：文章 → 关于 → 主题 → GitHub → RSS → 左栏第一项（文件夹按钮；无抽屉按钮插队）
   const nav = page.locator('.site-nav')
   for (let i = 0; i < 4; i++) await page.keyboard.press('Tab')
   await expect(nav.getByRole('link', { name: 'GitHub' })).toBeFocused()
@@ -1808,7 +1890,7 @@ test('desktop ≥1024px: drawer buttons hidden (no Tab insertion), sidebars pers
   await expect(nav.getByRole('link', { name: 'RSS' })).toBeFocused()
   await page.keyboard.press('Tab')
   await expect(
-    page.getByRole('navigation', { name: '文章索引' }).locator('.post-row').first(),
+    page.getByRole('navigation', { name: '文章索引' }).locator('.post-tree-folder').first(),
   ).toBeFocused()
 })
 

--- a/tests/unit/tree.test.ts
+++ b/tests/unit/tree.test.ts
@@ -1,0 +1,142 @@
+import type { Post } from '../../src/content/types.ts'
+
+import { describe, expect, it } from 'vitest'
+
+import { ancestorPaths, buildPostTree, type TreeNode } from '../../src/content/tree.ts'
+
+function post(slug: string, date: string): Post {
+  return { slug, title: slug, date, description: '', tags: [], draft: false, html: '', toc: [] }
+}
+
+/** 展平树：按先序收集全部文章 slug（用于无损断言） */
+function flattenSlugs(nodes: TreeNode[]): string[] {
+  return nodes.flatMap((node) =>
+    node.type === 'folder' ? flattenSlugs(node.children) : [node.post.slug],
+  )
+}
+
+/** 展平树：按先序收集节点标识（文件夹 = path，文章 = slug） */
+function flattenPaths(nodes: TreeNode[]): string[] {
+  return nodes.flatMap((node) =>
+    node.type === 'folder' ? [node.path, ...flattenPaths(node.children)] : [node.post.slug],
+  )
+}
+
+describe('buildPostTree: 树 = 内容清单（平铺列表）之上的派生结构', () => {
+  it('empty list derives an empty tree', () => {
+    expect(buildPostTree([])).toEqual([])
+  })
+
+  it('root-level posts only: leaves in date-desc order (flat contract preserved)', () => {
+    const tree = buildPostTree([
+      post('old', '2026-01-01'),
+      post('new', '2026-08-10'),
+      post('mid', '2026-05-05'),
+    ])
+
+    expect(tree.map((node) => (node.type === 'post' ? node.post.slug : node.path))).toEqual([
+      'new',
+      'mid',
+      'old',
+    ])
+  })
+
+  it('groups nested slugs under their directory folder, posts date-desc inside', () => {
+    const tree = buildPostTree([
+      post('root-a', '2026-08-10'),
+      post('pi-agent/02', '2026-08-09'),
+      post('pi-agent/01', '2026-08-12'),
+    ])
+
+    // 根层 = 文件夹 + 根层文章
+    expect(flattenPaths(tree)).toEqual(['pi-agent', 'pi-agent/01', 'pi-agent/02', 'root-a'])
+    const folder = tree[0]
+    expect(folder).toMatchObject({ type: 'folder', path: 'pi-agent', name: 'pi-agent' })
+    if (folder?.type === 'folder') {
+      expect(folder.children.map((node) => (node.type === 'post' ? node.post.slug : ''))).toEqual([
+        'pi-agent/01', // 日期倒序：01 (08-12) 在前
+        'pi-agent/02', // 02 (08-09) 在后
+      ])
+    }
+  })
+
+  it('sorts folders alphabetically before posts date-desc within a level', () => {
+    const tree = buildPostTree([
+      post('root-z', '2026-08-13'),
+      post('beta/1', '2026-08-10'),
+      post('alpha/1', '2026-08-10'),
+      post('root-a', '2026-08-12'),
+    ])
+
+    // 同层规则：文件夹（字母序）在前，文章（日期倒序：root-z 08-13 在 root-a 08-12 前）在后
+    expect(tree.map((node) => (node.type === 'folder' ? node.path : node.post.slug))).toEqual([
+      'alpha',
+      'beta',
+      'root-z',
+      'root-a',
+    ])
+  })
+
+  it('applies the same sorting rule recursively at every depth', () => {
+    const tree = buildPostTree([
+      post('a/post-late', '2026-08-01'),
+      post('a/folder-b/1', '2026-08-10'),
+      post('a/post-early', '2026-08-20'),
+      post('a/folder-a/1', '2026-08-10'),
+    ])
+
+    expect(flattenPaths(tree)).toEqual([
+      'a',
+      'a/folder-a', // 文件夹字母序：folder-a 在 folder-b 前
+      'a/folder-a/1',
+      'a/folder-b',
+      'a/folder-b/1',
+      'a/post-early', // 文件夹全部在前，其后文章日期倒序
+      'a/post-late',
+    ])
+  })
+
+  it('nests arbitrary-depth directories into a single tree', () => {
+    const tree = buildPostTree([
+      post('a/b/c/x', '2026-08-01'),
+      post('a/y', '2026-08-02'),
+      post('z', '2026-08-03'),
+    ])
+
+    expect(flattenPaths(tree)).toEqual(['a', 'a/b', 'a/b/c', 'a/b/c/x', 'a/y', 'z'])
+    const c = flattenSlugs(tree)
+    expect(c).toContain('a/b/c/x')
+  })
+
+  it('derives from the same source without loss or duplication and does not mutate the input list', () => {
+    const list = [
+      post('root', '2026-08-10'),
+      post('pi-agent/02', '2026-08-09'),
+      post('pi-agent/01', '2026-08-12'),
+      post('a/b/c', '2026-08-01'),
+    ]
+    const before = list.map((item) => item.slug)
+
+    const tree = buildPostTree(list)
+
+    // 树为清单之上的派生：每篇文章恰好出现一次（无丢失、无重复）
+    expect(flattenSlugs(tree).sort()).toEqual([...before].sort())
+    // 平铺契约不回归：输入清单不被修改（仍为原日期倒序清单）
+    expect(list.map((item) => item.slug)).toEqual(before)
+  })
+})
+
+describe('ancestorPaths: slug → 当前文章所在分支（需自动展开的祖先文件夹）', () => {
+  it('root-level slug has no ancestors', () => {
+    expect(ancestorPaths('hello-world')).toEqual([])
+    expect(ancestorPaths('prerendered-blog-with-vite')).toEqual([])
+  })
+
+  it('single-level nested slug expands its directory', () => {
+    expect(ancestorPaths('pi-agent/01')).toEqual(['pi-agent'])
+  })
+
+  it('arbitrary-depth slug expands every ancestor level in order', () => {
+    expect(ancestorPaths('a/b/c/post')).toEqual(['a', 'a/b', 'a/b/c'])
+  })
+})


### PR DESCRIPTION
由 Ralph / pi-afk 自动生成

实现 issue #44：新增 src/content/tree.ts（清单→层级树的纯派生，文件夹字母序前/文章日期倒序后递归同规则）与 src/components/PostTree.tsx（可折叠文件夹抽屉 + 当前分支自动展开 + nav-active/aria-current 高亮），PostIndex 复用为桌面侧栏与移动端抽屉同一树组件；补数据契约单测 10 条并改写/新增 e2e 用例，lint/typecheck/单测 60/e2e 75 全绿，已提交（Ralph: issue-44）。

Closes #44