### PR TITLE
Fix #40: 首页终端重构为 pi 风格会话演出 + 列表并行展示

### DIFF
--- a/src/components/HeroTerminal.tsx
+++ b/src/components/HeroTerminal.tsx
@@ -5,56 +5,175 @@ import { formatGitStats } from '../statusBar.ts'
 import { useTheme } from '../useTheme.ts'
 
 /**
- * hero 终端（issue #18，父 PRD #16）：pi.dev 风格 AI agent 会话演出。
+ * hero 终端（issue #40，父 PRD #16）：真实 AI 编码 agent 会话演出（pi 风格）。
+ *
+ * 结构（自上而下）：会话 transcript → 分隔线（────）→ 输入区 → 状态栏。
+ * 终端框架恒黑底白字（亮暗模式均如此，与页面 chrome 主题色解耦）、四角括号
+ * 装饰（┌┐└┘，不占文档流、不进可访问性树）。
+ *
+ * 每轮演出（全部数据驱动）：输入框自动逐字符打字输入问题 → 发送（问题进入
+ * transcript 成为用户行、输入框清空）→ Thinking… → Done. → 回答。
+ * 演出播放一遍后停驻最终态（不循环）：输入框为空、块状闪烁光标继续。
  *
  * 设计决策：
- * - 数据模型为「对话轮次」（TerminalTurn：❓ user 提问 / ▲ tool 工具调用 /
- *   assistant 回答），不再是「命令 + 输出」——文章数/标签数等仍由调用方从站点
- *   信息与内容清单自动计算，新增文章无需改渲染代码
- * - 终端框架（pi.dev 风格）：恒黑底白字（亮暗模式均如此，与页面 chrome 主题色
- *   解耦）、四角括号装饰（┌┐└┘）、底部 caption（● live 红点 + 弱化 mono 文字）；
- *   移除 mac 装饰圆点窗口栏（文章卡片行不沿用窗口栏形态，见 PostRow）
- * - 演出编排为纯 CSS：逐段入场（轮次按 --i * --turn-gap 依次错开）、tagline 打字机
- *   （clip-path + steps）、tool 块灰阶脉冲；自动播放一遍后停在最终态、不循环；
- *   live 红点除外——caption 精简为「● live」（去掉演出说明），红点以软脉冲无限
- *   循环（0.9s，opacity 1↔0.35，红色不变）；SSR 与客户端首帧都渲染完整对话文本
- *   （预渲染 HTML 含全文、SEO 不回归、无 hydration mismatch），
- *   prefers-reduced-motion 时 media query 整体禁用动画（含 live 点静止）、
- *   全文直接可见，无 JS 报错
- * - 底部 caption 扩展为终端状态栏（issue #42）：在「● live」基础上追加三段真实信息——
- *   站点版本（构建期注入 package.json version，v<version>）、当前主题（运行时状态，
- *   theme: light/dark，SSR 输出确定性值 + 水合后更新为实际主题，无 mismatch）、
- *   git 状态（构建期注入真实仓库统计 branch@sha · N commits，脏工作区分支后缀 *；
- *   git 不可得时该段优雅省略，构建与发布不受阻）
+ * - 数据模型为「轮次」（TerminalTurn：question + lines），不再区分
+ *   user/tool/assistant 角色行——问题经输入框演出后进入 transcript，输出行为
+ *   状态行（Thinking…/Done.，真实 agent 会话质感）与回答行（文本或任意节点，
+ *   如 GitHub 外链）。文章数/标签数仍由调用方从站点信息与内容清单自动计算，
+ *   新增文章/新增轮次无需改渲染代码
+ * - 演出编排为行级纯 CSS 动画：每条行与输入框打字各带 --delay（组件按数据
+ *   计算：字符数 × 打字速度 + 节奏参数，确定性输出，SSR 与水合一致），
+ *   动画本身延续既有纯 CSS 机制——打字机 = clip-path + steps(字符数) 逐字符
+ *   揭示；输入框打字 = 同一机制扩展到输入框内（input-type），发送时以 opacity
+ *   淡出清空（input-hide，与问题进入 transcript 同一时刻，两条动画作用于不同
+ *   属性互不干扰）；Thinking… 状态行带灰阶脉冲（3 次后停驻）；回答行淡入，
+ *   行内 typewriter 行逐字符揭示
+ * - 输入区：三轮问题各一个 .terminal-typed（绝对定位叠放于同一槽位，clip 动画
+ *   使同一时刻仅当前轮文本可见）；停驻光标 .terminal-input-cursor 在末轮发送后
+ *   出现（块状闪烁无限循环）；reduced-motion 时输入框全文直接可见
+ *   （问题行内排布、不重叠），全部动画禁用
+ * - 预渲染 HTML 含演出全文（输入框文本 + Thinking…/Done. + 回答 + 状态栏），
+ *   爬虫不执行 JS 可读，无 hydration mismatch
+ * - 状态栏：● live（红点软脉冲无限循环）+ 文章数 · 标签数（构建期自动计算）+
+ *   既有 issue #42 三段真实信息（版本 / 主题 / git）
  */
 
 /** 打字机参数：每字符耗时（总时长由文本长度驱动） */
 const TYPE_SPEED = 0.13
+/** 打字最短时长（输入框打字与行内揭示共用下限，issue #18 行为延续） */
+const MIN_TYPE = 1.5
 
-/** 对话轮次：驱动 hero 终端渲染（❓ user 提问 / ▲ tool 工具调用 / assistant 回答） */
-export type TerminalTurn =
-  | { role: 'user'; text: string }
-  | { role: 'tool'; call: string }
-  | {
-      role: 'assistant'
-      /** 回答行序列：文本或任意节点（如外链）；typewriter 仅对纯文本行生效 */
-      lines: { text: ReactNode; typewriter?: boolean }[]
-    }
+/** 演出节奏参数（秒） */
+const INPUT_IN = 0.25 // 输入区开始打字的延迟（hero 入场后）
+const SEND_PAUSE = 0.35 // 打字完成到发送的停顿
+const THINK_IN = 0.3 // 发送后 Thinking… 出现的延迟
+const THINK_DUR = 0.9 // Thinking… 持续到 Done.（与状态行脉冲 3 × 0.3s 同周期）
+const ANSWER_IN = 0.2 // Done. 到第一条回答的间隔
+const ANSWER_GAP = 0.25 // 回答行之间错开
+const LINE_IN = 0.3 // 行淡入时长
+const PARK_IN = 0.25 // 停驻光标在末轮发送后的出现延迟
+
+/** 终端输出行：agent 状态行（Thinking…/Done.）或回答行（文本或任意节点） */
+export type TerminalLine =
+  { status: 'thinking' | 'done'; text: string } | { text: ReactNode; typewriter?: boolean }
+
+/** 对话轮次：输入框打字的 question + 发送后依次揭示的输出行 */
+export interface TerminalTurn {
+  /** 输入框逐字符打字的问题；发送后作为用户行进入 transcript */
+  question: string
+  /** 发送后依次揭示的输出行（状态行/回答行，新增内容只需追加数据） */
+  lines: TerminalLine[]
+}
+
+/** 状态栏真实信息（文章数 · 标签数，调用方从内容清单构建期自动计算） */
+export interface SiteStats {
+  postCount: number
+  tagCount: number
+}
+
+/** 单轮时刻表：输入框打字窗口 / 发送时刻 / 各输出行揭示时刻 */
+export interface TurnTiming {
+  /** 输入框逐字符打字起始 */
+  typeStart: number
+  /** 打字时长（由问题字符数驱动） */
+  typeDuration: number
+  /** 发送时刻（问题进入 transcript + 输入框清空） */
+  sendTime: number
+  /** 各输出行揭示时刻（与 turn.lines 一一对应） */
+  lineTimes: number[]
+}
+
+/** 整场演出时刻表（数据驱动编排，确定性输出 → SSR/水合一致） */
+export interface TerminalTimeline {
+  rounds: TurnTiming[]
+  /** 演出总时长（末轮最后一行揭示完成） */
+  showEnd: number
+  /** 停驻光标出现时刻（末轮发送后，输入框清空） */
+  parkedDelay: number
+}
+
+function isStatus(line: TerminalLine): line is { status: 'thinking' | 'done'; text: string } {
+  return 'status' in line
+}
+
+/** 行揭示时长：状态行/普通回答淡入，typewriter 行按字符数（含最短下限） */
+function lineDuration(line: TerminalLine): number {
+  if (isStatus(line)) return LINE_IN
+  return line.typewriter && typeof line.text === 'string'
+    ? Math.max(line.text.length * TYPE_SPEED, MIN_TYPE)
+    : LINE_IN
+}
+
+/** 输入框打字时长：按问题字符数（含最短下限） */
+function typeDuration(question: string): number {
+  return Math.max(question.length * TYPE_SPEED, MIN_TYPE)
+}
 
 /**
- * 打字机文本（纯 CSS）：完整文本始终在 DOM 中（基础态 clip-path 不裁切），
- * animation 期间用 steps(字符数) 逐字符揭示；reduced-motion 下 animation 禁用
- * → 直接显示完整文本。--type-chars / --type-duration 由文本长度驱动；
- * 延迟由所在轮次（--i）与演出节奏（--turn-gap）经 CSS calc 计算。
+ * 由轮次数据计算整场演出时刻表（纯函数，无副作用）：
+ * 轮次严格串行——roundTotal = 最长一轮的总时长，第 r 轮打字起点 =
+ * r × roundTotal + INPUT_IN，发送 = 打字完成 + SEND_PAUSE，
+ * 输出行 = 发送后 Thinking… → Done. → 回答（各按节奏参数错开）。
  */
-function TypewriterText({ text }: { text: string }) {
+export function computeTurnTimings(turns: TerminalTurn[]): TerminalTimeline {
+  const roundSpans = turns.map((turn) => {
+    const statuses = turn.lines.filter(isStatus).length
+    const answers = turn.lines.filter((line) => !isStatus(line))
+    const thinkingSpan = statuses > 0 ? THINK_IN + (statuses - 1) * THINK_DUR : 0
+    const lastAnswerDur = answers.length > 0 ? lineDuration(answers[answers.length - 1]!) : 0
+    return (
+      INPUT_IN +
+      typeDuration(turn.question) +
+      SEND_PAUSE +
+      thinkingSpan +
+      ANSWER_IN +
+      Math.max(answers.length - 1, 0) * ANSWER_GAP +
+      lastAnswerDur
+    )
+  })
+  const roundTotal = roundSpans.length > 0 ? Math.max(...roundSpans) : 0
+
+  let lastSend = 0
+  const rounds = turns.map((turn, r) => {
+    const typeStart = r * roundTotal + INPUT_IN
+    const dur = typeDuration(turn.question)
+    const sendTime = typeStart + dur + SEND_PAUSE
+    lastSend = sendTime
+
+    const statuses = turn.lines.filter(isStatus).length
+    const answerBase =
+      sendTime + (statuses > 0 ? THINK_IN + (statuses - 1) * THINK_DUR : 0) + ANSWER_IN
+    let statusIndex = 0
+    let answerIndex = 0
+    const lineTimes = turn.lines.map((line) =>
+      isStatus(line)
+        ? sendTime + THINK_IN + statusIndex++ * THINK_DUR
+        : answerBase + answerIndex++ * ANSWER_GAP,
+    )
+    return { typeStart, typeDuration: dur, sendTime, lineTimes }
+  })
+
+  const showEnd =
+    rounds.length > 0
+      ? rounds[rounds.length - 1]!.lineTimes[turns[turns.length - 1]!.lines.length - 1]! +
+        lineDuration(turns[turns.length - 1]!.lines[turns[turns.length - 1]!.lines.length - 1]!)
+      : 0
+
+  return { rounds, showEnd, parkedDelay: lastSend + PARK_IN }
+}
+
+/** 打字机文本（纯 CSS）：完整文本始终在 DOM 中（基础态 clip-path 不裁切），
+ *  animation 期间用 steps(字符数) 逐字符揭示；reduced-motion 下 animation 禁用
+ *  → 直接显示完整文本。--type-chars / --type-duration / --delay 由数据驱动。 */
+function TypewriterText({ text, delay }: { text: string; delay: number }) {
   return (
     <span
       className="typewriter-text"
       style={
         {
           '--type-chars': text.length,
-          '--type-duration': `${Math.max(text.length * TYPE_SPEED, 1.5)}s`,
+          '--type-duration': `${Math.max(text.length * TYPE_SPEED, MIN_TYPE)}s`,
+          '--delay': `${delay}s`,
         } as CSSProperties
       }
     >
@@ -64,53 +183,55 @@ function TypewriterText({ text }: { text: string }) {
   )
 }
 
-/** 单轮渲染：user（❓ 加粗）/ tool（▲ 缩进 mono 脉冲）/ assistant（回答行） */
-function TurnRow({ turn, index }: { turn: TerminalTurn; index: number }) {
-  // 轮次序号：CSS 演出编排参数（入场错开 / 打字机与脉冲延迟由 calc(var(--i) …) 计算）
-  const style = { '--i': index } as CSSProperties
-
-  if (turn.role === 'user') {
-    return (
-      <div className="hero-turn hero-turn--user" style={style}>
-        <span className="user-question">
-          <span className="turn-mark" aria-hidden="true">
-            ❓
-          </span>
-          {turn.text}
-        </span>
-      </div>
-    )
-  }
-
-  if (turn.role === 'tool') {
-    return (
-      <div className="hero-turn hero-turn--tool" style={style}>
-        <span className="tool-call">
-          <span aria-hidden="true">▲</span> tool: {turn.call}
-        </span>
-      </div>
-    )
-  }
-
+/** 单轮渲染：问题行（发送时刻进入 transcript）+ 状态行（Thinking…/Done.）+ 回答行 */
+function TurnRow({ turn, timing }: { turn: TerminalTurn; timing: TurnTiming }) {
   return (
-    <div className="hero-turn hero-turn--answer" style={style}>
-      {turn.lines.map((line, i) => (
-        <div className="hero-line" key={i}>
-          {line.typewriter && typeof line.text === 'string' ? (
-            <TypewriterText text={line.text} />
-          ) : (
-            line.text
-          )}
-        </div>
-      ))}
+    <div className="hero-turn">
+      {/* 问题行：发送时刻淡入（与输入框清空同一时刻，--delay = sendTime） */}
+      <div className="user-question" style={{ '--delay': `${timing.sendTime}s` } as CSSProperties}>
+        <span className="turn-mark" aria-hidden="true">
+          ❓
+        </span>
+        {turn.question}
+      </div>
+      {turn.lines.map((line, j) => {
+        const delay = timing.lineTimes[j]!
+        if (isStatus(line)) {
+          return (
+            <div
+              key={j}
+              className={`terminal-status terminal-status--${line.status}`}
+              style={{ '--delay': `${delay}s` } as CSSProperties}
+            >
+              {line.text}
+            </div>
+          )
+        }
+        return (
+          <div key={j} className="hero-line" style={{ '--delay': `${delay}s` } as CSSProperties}>
+            {line.typewriter && typeof line.text === 'string' ? (
+              <TypewriterText text={line.text} delay={delay} />
+            ) : (
+              line.text
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }
 
-/** hero 终端（pi.dev 风格）：四角括号 + 会话轮次 + 底部状态栏 */
-export default function HeroTerminal({ turns }: { turns: TerminalTurn[] }) {
+/** hero 终端（pi 风格 AI 编码 agent 会话演出）：transcript → 分隔线 → 输入区 → 状态栏 */
+export default function HeroTerminal({
+  turns,
+  siteStats,
+}: {
+  turns: TerminalTurn[]
+  siteStats: SiteStats
+}) {
   // 当前主题：SSR/水合首帧输出确定性值 'light'，水合后更新为实际主题（无 mismatch）
   const theme = useTheme()
+  const timeline = computeTurnTimings(turns)
 
   return (
     <div className="hero-terminal" role="group" aria-label="AI 会话演出">
@@ -121,18 +242,71 @@ export default function HeroTerminal({ turns }: { turns: TerminalTurn[] }) {
       <span className="hero-terminal-corner hero-terminal-corner--tr" aria-hidden="true">
         ┐
       </span>
+
+      {/* 会话 transcript：每轮 = 问题行 + 状态行（Thinking…/Done.）+ 回答行，
+          行级动画由 --delay 编排（发送/状态/回答各按数据计算的时刻揭示） */}
       <div className="hero-terminal-scroll">
         <div className="hero-terminal-body">
           {turns.map((turn, i) => (
-            <TurnRow key={i} turn={turn} index={i} />
+            <TurnRow key={i} turn={turn} timing={timeline.rounds[i]!} />
           ))}
         </div>
       </div>
-      {/* 底部状态栏（issue #42）：● live · v<版本> · theme: <亮/暗> · git: <真实仓库统计>；
+
+      {/* 分隔线（────）：transcript 与输入区的分界（装饰性） */}
+      <div className="terminal-divider" aria-hidden="true">
+        ────
+      </div>
+
+      {/* 输入区：每轮一个 .terminal-typed（绝对定位叠放，clip 打字揭示 → 发送时
+          opacity 清空）；停驻光标末轮发送后出现，块状闪烁无限循环 */}
+      <div className="terminal-input-row">
+        <div className="terminal-input">
+          {turns.map((turn, i) => {
+            const t = timeline.rounds[i]!
+            return (
+              <span
+                key={i}
+                className="terminal-typed"
+                style={
+                  {
+                    '--type-chars': turn.question.length,
+                    '--type-duration': `${t.typeDuration}s`,
+                    '--delay-type': `${t.typeStart}s`,
+                    '--delay-hide': `${t.sendTime}s`,
+                  } as CSSProperties
+                }
+              >
+                <span className="terminal-input-text">{turn.question}</span>
+                <span className="terminal-cursor" aria-hidden="true" />
+              </span>
+            )
+          })}
+          <span
+            className="terminal-input-cursor"
+            aria-hidden="true"
+            style={{ '--delay-appear': `${timeline.parkedDelay}s` } as CSSProperties}
+          />
+        </div>
+      </div>
+
+      {/* 状态栏（issue #40 + #42）：● live · 文章数 · 标签数 · v<版本> · theme · git；
+          ● live 红点软脉冲无限循环；文章数/标签数构建期自动计算（调用方传入）；
           git 不可得时该段省略（role=status：主题切换时读屏播报更新） */}
       <div className="hero-terminal-caption" role="status" aria-label="终端状态栏">
         <span className="live-dot" aria-hidden="true" />
         <span className="status-item">live</span>
+        <span className="status-sep" aria-hidden="true">
+          ·
+        </span>
+        {/* 站点真实信息：文章数 · 标签数（构建期从内容清单计算，data-* 供 e2e 断言） */}
+        <span
+          className="status-item"
+          data-posts={siteStats.postCount}
+          data-tags={siteStats.tagCount}
+        >
+          {siteStats.postCount} 篇文章 · {siteStats.tagCount} 个标签
+        </span>
         <span className="status-sep" aria-hidden="true">
           ·
         </span>
@@ -165,6 +339,7 @@ export default function HeroTerminal({ turns }: { turns: TerminalTurn[] }) {
           </>
         )}
       </div>
+
       <span className="hero-terminal-corner hero-terminal-corner--bl" aria-hidden="true">
         └
       </span>

--- a/src/index.css
+++ b/src/index.css
@@ -197,8 +197,10 @@ html.dark .bg-texture {
 
 /* 终端框架（pi.dev 风格）：恒黑底白字，与页面 chrome 主题色解耦——亮暗模式均为
    黑底白字（不随 .dark 切换）；四角括号装饰（┌┐└┘）；移除 mac 装饰圆点窗口栏。
+   结构（issue #40）自上而下：会话 transcript → 分隔线（────）→ 输入区 → 状态栏。
    overflow 移到内部 .hero-terminal-scroll（横向滚动不影响四角括号）；
-   --turn-gap / --turn-in 为演出编排参数：轮次入场按 --i * --turn-gap 依次错开 */
+   演出编排为行级纯 CSS 动画：每条行与输入框打字各带 --delay（组件按数据计算，
+   确定性输出），播放一遍后停驻最终态、不循环 */
 .hero-terminal {
   position: relative;
   margin-top: 1.25rem;
@@ -208,8 +210,7 @@ html.dark .bg-texture {
   font-family: var(--font-mono);
   font-size: 0.875rem;
   line-height: 1.75;
-  --turn-gap: 0.5s;
-  --turn-in: 0.45s;
+  --line-in: 0.3s;
 }
 
 /* 四角括号：┌ ┐ └ ┘ 装饰在终端四角（重叠在边框线上，绝对定位不占文档流） */
@@ -246,11 +247,9 @@ html.dark .bg-texture {
   padding: 1rem 1rem 0.75rem;
 }
 
-/* 对话轮次：逐段入场（淡入 + 轻微上移），按轮次序号 --i 依次错开；
-   自动播放一遍（iteration-count 1）后停在最终态，不循环 */
+/* 对话轮次容器：结构分组（无容器入场动画——行级动画负责逐行揭示编排） */
 .hero-turn {
-  animation: turn-in var(--turn-in) ease-out both;
-  animation-delay: calc(var(--i) * var(--turn-gap));
+  display: block;
 }
 @keyframes turn-in {
   from {
@@ -263,25 +262,32 @@ html.dark .bg-texture {
   }
 }
 
-/* user 提问行：❓ 前缀 + 加粗（黑白下的第一视觉层级） */
+/* user 提问行：❓ 前缀 + 加粗（黑白下的第一视觉层级）；发送时刻淡入
+   （--delay = 发送时刻：问题进入 transcript 与输入框清空同一时刻） */
 .user-question {
   display: block;
   font-weight: 700;
+  animation: turn-in var(--line-in, 0.3s) ease-out both;
+  animation-delay: var(--delay, 0s);
 }
 .turn-mark {
   margin-right: 0.375rem;
 }
 
-/* tool 工具调用块：缩进 + mono + 灰阶脉冲（3 次后停在最终态，不循环）；
-   延迟等所在轮次入场后开始 */
-.hero-turn--tool .tool-call {
+/* agent 状态行（真实会话质感）：Thinking… / Done.——弱化灰阶，随 --delay 淡入；
+   Thinking… 带灰阶脉冲（3 × 0.3s = 与 THINK_DUR 同周期，3 次后停驻不循环） */
+.terminal-status {
   display: block;
-  margin-left: 1.5rem;
   color: #d6d6d6;
-  animation: tool-pulse 0.8s ease-in-out 3 both;
-  animation-delay: calc(var(--i) * var(--turn-gap) + 0.35s);
+  animation: turn-in var(--line-in, 0.3s) ease-out both;
+  animation-delay: var(--delay, 0s);
 }
-@keyframes tool-pulse {
+.terminal-status--thinking {
+  animation:
+    turn-in var(--line-in, 0.3s) ease-out var(--delay, 0s) both,
+    status-pulse 0.3s ease-in-out calc(var(--delay, 0s) + 0.2s) 3 both;
+}
+@keyframes status-pulse {
   0%,
   100% {
     color: #d6d6d6;
@@ -291,9 +297,12 @@ html.dark .bg-texture {
   }
 }
 
-/* assistant 回答行：常规文本；多行之间留白 */
+/* assistant 回答行：随 --delay 淡入；typewriter 行由行内 .typewriter-text
+   逐字符揭示（见下）；多行之间留白 */
 .hero-line {
   display: block;
+  animation: turn-in var(--line-in, 0.3s) ease-out both;
+  animation-delay: var(--delay, 0s);
 }
 .hero-line + .hero-line {
   margin-top: 0.25rem;
@@ -301,15 +310,15 @@ html.dark .bg-texture {
 
 /* 打字机文本（纯 CSS）：完整文本始终在 DOM（SEO / reduced-motion / 结束态直接可见），
    动画用 clip-path 从右向左裁切 + steps(字符数) 逐字符揭示；
-   --type-chars / --type-duration 由组件按文本长度驱动；
-   延迟由所在轮次（--i）与演出节奏（--turn-gap）计算：所在轮次入场后开始打字 */
+   --type-chars / --type-duration / --delay 由组件按数据驱动（issue #40：
+   打字机机制从行内揭示扩展到输入框内逐字符打字，见 .terminal-typed） */
 .typewriter-text {
   display: inline-block;
   clip-path: inset(0 0 0 0);
   animation-name: terminal-typing;
   animation-duration: var(--type-duration, 1.5s);
   animation-timing-function: steps(var(--type-chars, 14));
-  animation-delay: calc(var(--i, 0) * var(--turn-gap, 0.5s) + 0.3s);
+  animation-delay: var(--delay, 0s);
   animation-fill-mode: both;
 }
 @keyframes terminal-typing {
@@ -342,7 +351,87 @@ html.dark .bg-texture {
   }
 }
 
-/* 底部状态栏（issue #42）：● live · v<版本> · theme: <亮/暗> · git: <真实仓库统计>；
+/* 分隔线（────）：会话 transcript 与输入区之间的分界（issue #40，装饰性） */
+.terminal-divider {
+  padding: 0.125rem 0 0.375rem;
+  text-align: center;
+  font-size: 0.75rem;
+  line-height: 1;
+  color: #555;
+  user-select: none;
+}
+
+/* 输入区（issue #40）：终端底部输入框（演出用，非交互）。每轮一个 .terminal-typed
+   （绝对定位叠放于同一槽位，同一时刻仅当前轮文本可见）：
+   - 打字：clip-path + steps(字符数) 逐字符揭示（input-type，延续行内打字机同一机制）
+   - 发送：opacity 淡出清空（input-hide，与问题进入 transcript 同一时刻）——
+     两条动画作用于不同属性（clip-path / opacity），互不干扰且各自 fill both
+   - 停驻光标：末轮发送后出现在输入框行首，块状闪烁无限循环（演出停驻态） */
+.terminal-input-row {
+  padding: 0 1rem 0.75rem;
+}
+.terminal-input {
+  position: relative;
+  min-height: 2.1rem;
+  border: 1px solid #3a3a3a;
+  border-radius: 0.25rem;
+  background: #0d0d0d;
+  padding: 0.4rem 0.625rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+.terminal-typed {
+  position: absolute;
+  top: 0.4rem;
+  left: 0.625rem;
+  white-space: nowrap;
+  /* 基础态完整可见（reduced-motion / 无动画时输入框直接显示全文） */
+  clip-path: inset(0 0 0 0);
+  animation:
+    input-type var(--type-duration, 1.5s) steps(var(--type-chars, 8)) var(--delay-type, 0s) both,
+    input-hide 0.2s ease var(--delay-hide, 30s) both;
+}
+@keyframes input-type {
+  from {
+    clip-path: inset(0 100% 0 0);
+  }
+  to {
+    clip-path: inset(0 0 0 0);
+  }
+}
+@keyframes input-hide {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+/* 停驻光标：clip 隐藏直到 --delay-appear（末轮发送后），随后块状闪烁继续
+   （块状视觉与行内 .terminal-cursor 同一形态：白块 + 闪烁） */
+.terminal-input-cursor {
+  position: absolute;
+  top: 0.4rem;
+  left: 0.625rem;
+  display: inline-block;
+  width: 0.55em;
+  height: 1.05em;
+  background: #fff;
+  clip-path: inset(0 0 0 0);
+  animation:
+    terminal-blink 1.1s steps(1) infinite,
+    cursor-appear 0.01s linear var(--delay-appear, 60s) both;
+}
+@keyframes cursor-appear {
+  from {
+    clip-path: inset(0 100% 0 0);
+  }
+  to {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+/* 底部状态栏（issue #40 + #42）：● live · 文章数 · 标签数 · v<版本> · theme · git；
    弱化 mono 文字（与正文以细线分隔）、段间以「·」分隔，多段在窄屏换行不撑破小屏 */
 .hero-terminal-caption {
   display: flex;
@@ -411,12 +500,10 @@ html.dark .terminal-dot--green {
 
 /* ===== 文章列表（issue #19，父 PRD #16）：连续终端流最后一幕 ===== */
 
-/* 连续终端流容器：--turn-gap / --turn-in 与 hero 终端演出同一节奏参数
-   （.hero-terminal 内同名变量同值，这里作为文章行时序的公共来源）；
-   --row-gap / --row-in 为文章行逐行错开的节奏 */
+/* 连续终端流容器：--row-start / --row-gap / --row-in 为文章行入场节奏参数
+   （issue #40：与 hero 终端演出并行开始，不再等演出播完） */
 .home-stream {
-  --turn-gap: 0.5s;
-  --turn-in: 0.45s;
+  --row-start: 0.4s;
   --row-gap: 0.14s;
   --row-in: 0.3s;
 }
@@ -428,14 +515,11 @@ html.dark .terminal-dot--green {
   margin-top: 1.25rem;
 }
 
-/* 行入场：最后一幕。延迟 = 会话演出总时长（轮次数 × 错开 + 末轮入场时长）
-   之后再开始——演出停驻最终态后文章行才逐行错开入场（终端逐行输出感） */
+/* 行入场：与 hero 终端演出并行开始（issue #40）——入场延迟（--row-start）不再大于
+   演出末段（首行 ~0.4s 即开始，而演出末轮回答在数秒后），保留逐行错开 fade-in */
 .post-row-enter {
   animation: row-in var(--row-in, 0.3s) ease-out both;
-  animation-delay: calc(
-    var(--turn-count, 0) * var(--turn-gap, 0.5s) + var(--turn-in, 0.45s) + 0.45s + var(--i, 0) *
-      var(--row-gap, 0.14s)
-  );
+  animation-delay: calc(var(--row-start, 0.4s) + var(--i, 0) * var(--row-gap, 0.14s));
 }
 @keyframes row-in {
   from {
@@ -1026,18 +1110,33 @@ html.dark .drawer-panel {
   overflow-wrap: anywhere;
 }
 
-/* 无障碍：prefers-reduced-motion 下禁用打字机 / 入场 / 工具脉冲 / live 点 / 光标闪烁
-   动画，全文直接可见（live 红点静止、演出全文直接可见；无动画报错；演出编排为纯
-   CSS，无 JS 参与） */
+/* 无障碍：prefers-reduced-motion 下禁用全部动画，全文直接可见——问题/状态/回答行、
+   输入框打字文本（问题行内排布、不重叠不隐藏）、live 红点静止、光标静止；
+   无动画报错（演出编排为纯 CSS，无 JS 参与） */
 @media (prefers-reduced-motion: reduce) {
   .hero-enter,
-  .hero-turn,
+  .user-question,
+  .terminal-status,
+  .hero-line,
   .typewriter-text,
-  .hero-turn--tool .tool-call,
+  .terminal-typed,
+  .terminal-input-cursor,
   .live-dot,
   .terminal-cursor,
   .post-row-enter {
     animation: none;
+  }
+  /* 输入区：输入框全文直接可见（问题按顺序行内排布，不再绝对定位叠放）；
+     光标闪烁同为动画 → 静止（隐藏输入区光标，避免与文本重叠） */
+  .terminal-typed {
+    position: static;
+    display: inline-block;
+    margin-right: 0.5em;
+    opacity: 1;
+  }
+  .terminal-typed .terminal-cursor,
+  .terminal-input-cursor {
+    display: none;
   }
   /* 平滑滚动回退瞬时跳转（issue #30） */
   html {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,3 @@
-import { type CSSProperties } from 'react'
-
 import BackgroundDots from '../components/BackgroundDots.tsx'
 import HeroTerminal, { type TerminalTurn } from '../components/HeroTerminal.tsx'
 import PostRow from '../components/PostRow.tsx'
@@ -8,33 +6,46 @@ import { authorBio, githubUrl, siteName, tagline } from '../site.ts'
 
 /**
  * 首页 = 连续终端流（父 PRD #16「一台恒黑底的连续终端流」收尾）：
- * hero（大号站点名 h1 + pi.dev 风格 AI 会话演出终端）+ 文章列表（终端输出行）。
- * 终端内容由「对话轮次」数据结构驱动（user 提问 / tool 工具调用 / assistant 回答，
- * issue #18）：文章数/标签数从内容清单自动计算（新增文章无需改代码），
- * 简介/tagline 沿用站点信息，GitHub 外链真实指向仓库。
- * 文章区为终端输出行（mono 日期 + 标题 + #标签，issue #19）：会话演出结束后
- * （停驻最终态）作为最后一幕逐行错开入场，入场时序由 --turn-count（轮次数）与
- * hero 终端同一节奏参数（--turn-gap / --turn-in）在 CSS 侧计算——新增文章自动
- * 增长行数，无需改代码。
+ * hero（大号站点名 h1 + pi 风格 AI 编码 agent 会话演出终端）+ 文章列表（终端输出行）。
+ * 终端为「会话 transcript → 分隔线 → 输入区 → 状态栏」结构（issue #40）：
+ * 每轮问答经输入框演出（自动逐字符打字 → 发送进 transcript → Thinking… → Done. →
+ * 回答），三轮全部经输入框、信息不缩水（简介 + tagline / 文章数·标签数 / GitHub 外链）。
+ * 演出文本全部数据驱动（turns 数组 + 构建期计算的文章数/标签数）：新增内容
+ * （新增文章、新增轮次）无需改渲染代码。
+ * 文章区为终端输出行（mono 日期 + 标题 + #标签，issue #19）：与 hero 终端演出
+ * 并行入场（issue #40，入场延迟不再大于演出末段），逐行错开 fade-in 保留。
  */
 export default function Home() {
   // ls posts 的文章数/标签数：来自构建期内容清单（非 draft），自动计算
   const postCount = posts.length
   const tagCount = new Set(posts.flatMap((post) => post.tags)).size
 
-  // 三轮问答剧本（issue #18）：你是谁 / 这个站有什么 / 怎么联系
+  // 三轮问答剧本（issue #40）：你是谁 / 这个站有什么 / 怎么联系——
+  // question 经输入框打字演出后进入 transcript；lines 为发送后依次揭示的
+  // 输出行（状态行 Thinking…/Done. + 回答行），回答全文保留
   const turns: TerminalTurn[] = [
-    { role: 'user', text: '你是谁' },
-    { role: 'tool', call: 'read about.md' },
-    { role: 'assistant', lines: [{ text: authorBio }, { text: tagline, typewriter: true }] },
-    { role: 'user', text: '这个站有什么' },
-    { role: 'tool', call: 'ls posts' },
-    { role: 'assistant', lines: [{ text: `${postCount} 篇文章 · ${tagCount} 个标签` }] },
-    { role: 'user', text: '怎么联系' },
-    { role: 'tool', call: 'open github.com/hacxy' },
     {
-      role: 'assistant',
+      question: '你是谁',
       lines: [
+        { text: 'Thinking…', status: 'thinking' },
+        { text: 'Done.', status: 'done' },
+        { text: authorBio },
+        { text: tagline, typewriter: true },
+      ],
+    },
+    {
+      question: '这个站有什么',
+      lines: [
+        { text: 'Thinking…', status: 'thinking' },
+        { text: 'Done.', status: 'done' },
+        { text: `${postCount} 篇文章 · ${tagCount} 个标签` },
+      ],
+    },
+    {
+      question: '怎么联系',
+      lines: [
+        { text: 'Thinking…', status: 'thinking' },
+        { text: 'Done.', status: 'done' },
         {
           text: (
             <a href={githubUrl} target="_blank" rel="noopener noreferrer">
@@ -50,17 +61,13 @@ export default function Home() {
     <>
       {/* 背景点阵动画（ArtDots 改编）：仅首页挂载、仅客户端渲染（SSR 输出 null） */}
       <BackgroundDots />
-      {/* 连续终端流容器：--turn-count 供文章行入场延迟计算——
-          会话演出结束后（停驻最终态）文章行作为最后一幕逐行错开入场；
-          内层 max-w-2xl 收窄居中：全站容器放宽为 max-w-6xl 后首页视觉零回归（issue #28） */}
-      <div
-        className="home-stream mx-auto max-w-2xl"
-        style={{ '--turn-count': turns.length } as CSSProperties}
-      >
+      {/* 连续终端流容器：内层 max-w-2xl 收窄居中：全站容器放宽为 max-w-6xl 后
+          首页视觉零回归（issue #28）；文章行入场节奏参数见 .home-stream */}
+      <div className="home-stream mx-auto max-w-2xl">
         {/* hero 区：克制的入场动画（淡入 + 轻微上移，纯 CSS，reduced-motion 禁用） */}
         <section className="hero-enter">
           <h1 className="font-mono text-4xl font-bold tracking-tight">{siteName}</h1>
-          <HeroTerminal turns={turns} />
+          <HeroTerminal turns={turns} siteStats={{ postCount, tagCount }} />
         </section>
         <ul className="post-row-list">
           {posts.map((post, i) => (

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -16,23 +16,23 @@ test('hero: big h1 site name + AI agent conversation (three Q&A rounds)', async 
   const heading = page.getByRole('heading', { level: 1, name: 'Hacxy' })
   await expect(heading).toBeVisible()
 
-  // pi.dev 风格会话演出终端可见
+  // pi 风格 AI 编码 agent 会话演出终端可见
   const terminal = page.locator('.hero-terminal')
   await expect(terminal).toBeVisible()
 
-  // 三轮问答的 ❓ user 提问行（加粗，黑白下的第一视觉层级）
+  // 三轮问答全部经输入框演出（issue #40）：问题既在输入框（逐字符打字的文本）
+  // 也在 transcript（❓ 用户行，加粗 = 黑白下的第一视觉层级）
   for (const question of ['你是谁', '这个站有什么', '怎么联系']) {
+    const typed = terminal.locator('.terminal-input-text').filter({ hasText: question })
+    await expect(typed).toBeVisible()
     const q = terminal.locator('.user-question').filter({ hasText: question })
     await expect(q).toBeVisible()
     expect(await q.evaluate((el) => getComputedStyle(el).fontWeight)).toBe('700')
   }
 
-  // ▲ tool 工具调用块（缩进 + mono + 灰阶脉冲）：read about.md / ls posts / open github.com/hacxy
-  for (const call of ['read about.md', 'ls posts', 'open github.com/hacxy']) {
-    const tool = terminal.locator('.tool-call').filter({ hasText: call })
-    await expect(tool).toBeVisible()
-    expect(await tool.evaluate((el) => getComputedStyle(el).fontFamily)).toContain('JetBrains Mono')
-  }
+  // 每轮发送后：Thinking… → Done.（agent 状态行，三轮各一对）
+  await expect(terminal.locator('.terminal-status--thinking')).toHaveCount(3)
+  await expect(terminal.locator('.terminal-status--done')).toHaveCount(3)
 
   // assistant 回答：简介 + tagline（打字机结束态全文可见，不做时序断言）
   await expect(terminal.getByText(/前端工程师/)).toBeVisible()
@@ -57,9 +57,18 @@ test('hero terminal: ls posts counts match the content manifest', async ({ page 
 
   await page.goto('/')
   const terminal = page.locator('.hero-terminal')
-  // 输出形如「3 篇文章 · 4 个标签」（文章数/标签数自动计算）
-  await expect(terminal.getByText(new RegExp(`${postCount} 篇文章`))).toBeVisible()
-  await expect(terminal.getByText(new RegExp(`${tagCount} 个标签`))).toBeVisible()
+
+  // 回答行输出形如「3 篇文章 · 4 个标签」（文章数/标签数自动计算）
+  await expect(
+    terminal.locator('.hero-line').filter({ hasText: new RegExp(`${postCount} 篇文章`) }),
+  ).toBeVisible()
+
+  // 状态栏（issue #40）：同一信息随 ● live 并入状态栏（构建期自动计算，data-* 供断言）
+  const statsItem = terminal.locator('.hero-terminal-caption [data-posts]')
+  await expect(statsItem).toBeVisible()
+  await expect(statsItem).toHaveAttribute('data-posts', String(postCount))
+  await expect(statsItem).toHaveAttribute('data-tags', String(tagCount))
+  await expect(statsItem).toHaveText(new RegExp(`${postCount} 篇文章 · ${tagCount} 个标签`))
 })
 
 test('hero terminal: always black background with white text in light and dark themes', async ({
@@ -82,7 +91,7 @@ test('hero terminal: always black background with white text in light and dark t
   await expect(terminal).toHaveCSS('color', 'rgb(255, 255, 255)')
 })
 
-test('hero terminal: four corner brackets + bottom status bar (red live dot, weak mono text) (issue #42)', async ({
+test('hero terminal: transcript → divider (────) → input → status bar structure (issue #40)', async ({
   page,
 }) => {
   await page.goto('/')
@@ -92,6 +101,37 @@ test('hero terminal: four corner brackets + bottom status bar (red live dot, wea
   const corners = terminal.locator('.hero-terminal-corner')
   await expect(corners).toHaveCount(4)
   expect((await corners.allTextContents()).sort()).toEqual(['┌', '┐', '└', '┘'].sort())
+
+  // 终端内部结构自上而下：会话 transcript → 分隔线（────）→ 输入区 → 状态栏
+  const order = await page.evaluate(() => {
+    const sels = [
+      '.hero-terminal-body',
+      '.terminal-divider',
+      '.terminal-input-row',
+      '.hero-terminal-caption',
+    ]
+    const nodes = sels.map((sel) => document.querySelector(sel))
+    const follows = (a: Element, b: Element) =>
+      !!(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
+    return [
+      follows(nodes[0]!, nodes[1]!),
+      follows(nodes[1]!, nodes[2]!),
+      follows(nodes[2]!, nodes[3]!),
+    ]
+  })
+  expect(order).toEqual([true, true, true])
+
+  // 分隔线 = ────（box-drawing 字符，装饰性不进可访问性树）
+  const divider = terminal.locator('.terminal-divider')
+  await expect(divider).toBeVisible()
+  await expect(divider).toHaveText('────')
+  expect(await divider.getAttribute('aria-hidden')).toBe('true')
+
+  // 输入区 = 输入框（演出用，非交互）：三轮问题各一个打字文本 + 停驻光标
+  const input = terminal.locator('.terminal-input')
+  await expect(input).toBeVisible()
+  await expect(input.locator('.terminal-typed')).toHaveCount(3)
+  await expect(input.locator('.terminal-input-cursor')).toHaveCount(1)
 
   // 底部 caption = 终端状态栏（issue #42）：● live · v<版本> · theme · git
   const caption = terminal.locator('.hero-terminal-caption')
@@ -108,7 +148,7 @@ test('hero terminal: four corner brackets + bottom status bar (red live dot, wea
   await expect(dot).toBeVisible()
   expect(await dot.evaluate((el) => getComputedStyle(el).backgroundColor)).toBe('rgb(239, 68, 68)')
 
-  // 状态段三段真实信息各自存在（内容由专门用例从源计算断言）：版本 / 主题 / git
+  // 状态段真实信息各自存在（内容由专门用例从源计算断言）：版本 / 主题 / git
   await expect(caption.locator('.status-item').filter({ hasText: /^v\d/ })).toBeVisible()
   await expect(caption.locator('[data-theme]')).toBeVisible()
   await expect(caption.locator('[data-git-branch]')).toBeVisible()
@@ -218,23 +258,28 @@ test('status bar: git stats computed from the real repository (issue #42)', asyn
 test('prerendered HTML contains the full conversation text (SEO no regression)', async ({
   request,
 }) => {
-  // 站点名 h1 + 三轮问答全文（user 提问 / tool 调用 / assistant 回答 / caption）
-  // 都在预渲染源码中（爬虫不执行 JS 即可读）。注：React SSR 会在混合静态文本与
-  // 表达式的节点间插入 <!-- --> 注释（文本本身连续），故先剥离再断言全文
+  // 站点名 h1 + 三轮问答全文（输入框打字文本 + transcript 问题行 + Thinking…/Done. +
+  // 回答 + 分隔线 + 状态栏）都在预渲染源码中（爬虫不执行 JS 即可读）。注：React SSR
+  // 会在混合静态文本与表达式的节点间插入 <!-- --> 注释（文本本身连续），先剥离再断言全文
   const html = (await (await request.get('/')).text()).replaceAll('<!-- -->', '')
 
   expect(html).toContain('Hacxy')
-  expect(html).toContain('你是谁')
-  expect(html).toContain('这个站有什么')
-  expect(html).toContain('怎么联系')
-  expect(html).toContain('tool: read about.md')
-  expect(html).toContain('tool: ls posts')
-  expect(html).toContain('tool: open github.com/hacxy')
+  // 三轮问题：transcript 用户行 + 输入框打字文本（输入框文本同样进预渲染 HTML）
+  for (const q of ['你是谁', '这个站有什么', '怎么联系']) {
+    expect(html).toContain(q)
+  }
+  // 每轮发送后的 agent 状态行：Thinking… → Done.
+  expect(html).toContain('Thinking…')
+  expect(html).toContain('Done.')
+  // 回答全文
   expect(html).toContain('前端工程师')
   expect(html).toContain('了解真相，才能获得真正的自由')
   expect(html).toContain('https://github.com/hacxy')
+  // 分隔线（────）
+  expect(html).toContain('────')
+  // 状态栏（issue #40 + #42）：live + 文章数·标签数 + 版本 + theme: light
   expect(html).toContain('live')
-  // 状态栏（issue #42）构建期注入/确定性值同样在预渲染源码中：版本 + theme: light
+  expect(html).toContain('篇文章')
   const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8')) as {
     version: string
   }
@@ -242,17 +287,18 @@ test('prerendered HTML contains the full conversation text (SEO no regression)',
   expect(html).toContain('theme: light')
 })
 
-test('hero terminal: CSS show plays once and stops; live dot pulses infinitely', async ({
+test('hero terminal: CSS show plays once and stops; live dot + parked cursor pulse infinitely', async ({
   page,
 }) => {
   await page.goto('/')
   const terminal = page.locator('.hero-terminal')
 
-  // 演出动画均播放一遍后停驻：逐段入场 1 次、打字机 1 次、工具脉冲 3 次（不循环）；
-  // 仅 live 红点无限循环（软脉冲，0.9s）——持续闪烁的 live 状态指示
+  // 演出动画均播放一遍后停驻：问题行淡入 1 次、行内打字机 1 次、Thinking… 脉冲 3 次
+  // （3 × 0.3s = 与 THINK_DUR 同周期）、输入框打字（input-type）与清空（input-hide）
+  // 各 1 次且 fill both → 停驻最终态；不循环
   expect(
     await terminal
-      .locator('.hero-turn')
+      .locator('.user-question')
       .first()
       .evaluate((el) => getComputedStyle(el).animationIterationCount),
   ).toBe('1')
@@ -263,31 +309,124 @@ test('hero terminal: CSS show plays once and stops; live dot pulses infinitely',
   ).toBe('1')
   expect(
     await terminal
-      .locator('.tool-call')
+      .locator('.terminal-status--thinking')
       .first()
       .evaluate((el) => getComputedStyle(el).animationIterationCount),
-  ).toBe('3')
+  ).toBe('1, 3')
+  expect(
+    await terminal
+      .locator('.terminal-typed')
+      .first()
+      .evaluate((el) => getComputedStyle(el).animationIterationCount),
+  ).toBe('1, 1')
+  expect(
+    await terminal
+      .locator('.terminal-typed')
+      .first()
+      .evaluate((el) => getComputedStyle(el).animationName),
+  ).toBe('input-type, input-hide')
+
+  // 仅 live 红点无限循环（软脉冲，0.9s，opacity 1↔0.35）——持续闪烁的 live 状态指示
   expect(
     await terminal
       .locator('.live-dot')
       .evaluate((el) => getComputedStyle(el).animationIterationCount),
   ).toBe('infinite')
-  // live 点软脉冲周期 0.9s（opacity 1↔0.35）
   expect(
     await terminal.locator('.live-dot').evaluate((el) => getComputedStyle(el).animationDuration),
   ).toBe('0.9s')
+  // 停驻光标：末轮发送后出现（cursor-appear 1 次）并块状闪烁无限循环（演出停驻态）
+  expect(
+    await terminal
+      .locator('.terminal-input-cursor')
+      .evaluate((el) => getComputedStyle(el).animationIterationCount),
+  ).toBe('infinite, 1')
 
-  // 等演出播完（9 轮 × 0.5s 错开 + 入场时长 + 打字机/脉冲尾段），停在最终态：
-  // 最后一轮完全可见（opacity 1），tagline 全文揭示
+  // 等演出播完，停在最终态：末轮回答完全可见（opacity 1）、tagline 全文揭示、
+  // 输入框全部清空（每轮打字文本 opacity 0）、停驻光标出现在输入框
   await expect
-    .poll(() =>
-      terminal
-        .locator('.hero-turn')
-        .last()
-        .evaluate((el) => getComputedStyle(el).opacity),
+    .poll(
+      () =>
+        terminal
+          .locator('.hero-line')
+          .last()
+          .evaluate((el) => getComputedStyle(el).opacity),
+      { timeout: 25_000 },
     )
     .toBe('1')
   await expect(terminal.getByText('了解真相，才能获得真正的自由')).toBeVisible()
+  for (let i = 0; i < 3; i++) {
+    expect(
+      await terminal
+        .locator('.terminal-typed')
+        .nth(i)
+        .evaluate((el) => getComputedStyle(el).opacity),
+    ).toBe('0')
+  }
+  await expect(terminal.locator('.terminal-input-cursor')).toBeVisible()
+})
+
+test('hero terminal: per-round choreography — input types, then send, then Thinking… → Done. → answer', async ({
+  page,
+}) => {
+  await page.goto('/')
+  const terminal = page.locator('.hero-terminal')
+  const typed = terminal.locator('.terminal-typed')
+
+  // 每轮：输入框逐字符打字（第 0 条动画）先开始，发送（第 1 条动画 = 输入框清空）在后
+  const delays = (el: Element) =>
+    getComputedStyle(el)
+      .animationDelay.split(',')
+      .map((d) => parseFloat(d))
+  const [typeDelay0, hideDelay0] = await typed.first().evaluate(delays)
+  expect(typeDelay0!).toBeGreaterThan(0)
+  expect(hideDelay0!).toBeGreaterThan(typeDelay0!)
+
+  for (let r = 0; r < 3; r++) {
+    const turn = terminal.locator('.hero-turn').nth(r)
+    // 发送：问题进入 transcript（user-question 淡入）与输入框清空（input-hide）同一时刻
+    const questionDelay = parseFloat(
+      await turn.locator('.user-question').evaluate((el) => getComputedStyle(el).animationDelay),
+    )
+    const roundHide = (await typed.nth(r).evaluate(delays))[1]!
+    expect(questionDelay).toBe(roundHide)
+
+    // 状态行与回答行依次晚于发送：Thinking… → Done. → 回答
+    const thinkingDelay = (await turn
+      .locator('.terminal-status--thinking')
+      .evaluate((el) => getComputedStyle(el).animationDelay.split(',')[0]))!
+    const doneDelay = parseFloat(
+      await turn
+        .locator('.terminal-status--done')
+        .evaluate((el) => getComputedStyle(el).animationDelay),
+    )
+    expect(parseFloat(thinkingDelay)).toBeGreaterThan(questionDelay)
+    expect(doneDelay).toBeGreaterThan(parseFloat(thinkingDelay))
+    const answerDelay = parseFloat(
+      await turn
+        .locator('.hero-line')
+        .first()
+        .evaluate((el) => getComputedStyle(el).animationDelay),
+    )
+    expect(answerDelay).toBeGreaterThan(doneDelay)
+  }
+
+  // 轮次严格串行（真实会话顺序）：下一轮输入框打字不早于上一轮最后一行揭示
+  const nextType = (await typed.nth(1).evaluate(delays))[0]!
+  const firstRoundLastAnswer = parseFloat(
+    await terminal
+      .locator('.hero-turn')
+      .nth(0)
+      .locator('.hero-line')
+      .last()
+      .evaluate((el) => getComputedStyle(el).animationDelay),
+  )
+  expect(nextType).toBeGreaterThan(firstRoundLastAnswer)
+
+  // 停驻光标：末轮发送后出现（演出停驻态，块状闪烁继续）
+  const lastHide = (await typed.nth(2).evaluate(delays))[1]!
+  const cursorAppear = (await terminal.locator('.terminal-input-cursor').evaluate(delays))[1]!
+  expect(cursorAppear).toBeGreaterThan(lastHide)
 })
 
 test('hero terminal: reduced-motion skips all animations, full text visible, no errors', async ({
@@ -298,33 +437,41 @@ test('hero terminal: reduced-motion skips all animations, full text visible, no 
 
   await page.emulateMedia({ reducedMotion: 'reduce' })
   await page.goto('/')
+  const terminal = page.locator('.hero-terminal')
 
-  // 全文直接可见（无需等待动画）：三轮提问 + tool 调用 + tagline 全文
-  for (const text of ['你是谁', '这个站有什么', '怎么联系', '了解真相，才能获得真正的自由']) {
-    await expect(page.getByText(text).first()).toBeVisible()
+  // 全文直接可见（无需等待动画）：三轮提问（transcript 用户行 + 输入框打字文本）、
+  // 状态行 Thinking…/Done.、回答（简介 + tagline 全文）
+  for (const text of ['你是谁', '这个站有什么', '怎么联系']) {
+    await expect(terminal.locator('.user-question').filter({ hasText: text })).toBeVisible()
+    await expect(terminal.locator('.terminal-input-text').filter({ hasText: text })).toBeVisible()
   }
+  await expect(terminal.locator('.terminal-status--thinking').first()).toBeVisible()
+  await expect(terminal.locator('.terminal-status--done').first()).toBeVisible()
+  await expect(terminal.getByText('了解真相，才能获得真正的自由')).toBeVisible()
 
-  // 逐段入场 / 打字机 / 工具脉冲 / live 点脉冲 / hero 入场全部禁用（animation: none）
+  // 全部动画禁用（animation: none）：问题行淡入 / 状态行 / 打字机 / 输入框打字与清空 /
+  // 停驻光标 / live 点脉冲 / hero 入场
+  for (const sel of [
+    '.user-question',
+    '.terminal-status',
+    '.typewriter-text',
+    '.terminal-typed',
+    '.terminal-input-cursor',
+    '.live-dot',
+    '.hero-enter',
+  ]) {
+    const root = sel === '.hero-enter' ? page : terminal
+    expect(
+      await root
+        .locator(sel)
+        .first()
+        .evaluate((el) => getComputedStyle(el).animationName),
+    ).toBe('none')
+  }
+  // 输入区：输入框全文直接可见（问题行内排布，不重叠不隐藏）；输入区光标隐藏
+  await expect(terminal.locator('.terminal-typed').first()).toBeVisible()
   expect(
-    await page
-      .locator('.hero-turn')
-      .first()
-      .evaluate((el) => getComputedStyle(el).animationName),
-  ).toBe('none')
-  expect(
-    await page.locator('.typewriter-text').evaluate((el) => getComputedStyle(el).animationName),
-  ).toBe('none')
-  expect(
-    await page
-      .locator('.tool-call')
-      .first()
-      .evaluate((el) => getComputedStyle(el).animationName),
-  ).toBe('none')
-  expect(await page.locator('.live-dot').evaluate((el) => getComputedStyle(el).animationName)).toBe(
-    'none',
-  )
-  expect(
-    await page.locator('.hero-enter').evaluate((el) => getComputedStyle(el).animationName),
+    await terminal.locator('.terminal-input-cursor').evaluate((el) => getComputedStyle(el).display),
   ).toBe('none')
   // 全程无动画/脚本报错
   expect(pageErrors).toHaveLength(0)
@@ -424,7 +571,7 @@ test('post row hover feedback: terminal prompt fades in + title underline, no ba
   await expect(row.locator('.post-row-tag').first()).toHaveCSS('color', 'rgb(158, 158, 158)')
 })
 
-test('post list entrance: last act of the stream, staggered after the conversation ends', async ({
+test('post list entrance: parallel with the hero show, staggered fade-in (issue #40)', async ({
   page,
 }) => {
   await page.goto('/')
@@ -433,15 +580,17 @@ test('post list entrance: last act of the stream, staggered after the conversati
 
   // 行入场为纯 CSS（淡入 + 轻微上移，与 hero 逐段入场同节奏）
   await expect(firstRow).toHaveCSS('animation-name', 'row-in')
-  // 入场延迟在会话演出结束之后（最后一轮完全可见后才开始入场）
+  // 入场与终端演出并行开始（issue #40）：入场延迟不再大于演出末段——首行在演出
+  // 早期即开始入场（旧行为：等演出播完才作为最后一幕入场）；末轮回答揭示时刻晚得多
   const rowDelay = parseFloat(await firstRow.evaluate((el) => getComputedStyle(el).animationDelay))
-  const lastTurnDelay = parseFloat(
+  expect(rowDelay).toBeLessThan(5)
+  const lastAnswerDelay = parseFloat(
     await terminal
-      .locator('.hero-turn')
+      .locator('.hero-line')
       .last()
       .evaluate((el) => getComputedStyle(el).animationDelay),
   )
-  expect(rowDelay).toBeGreaterThan(lastTurnDelay + 0.45)
+  expect(rowDelay).toBeLessThan(lastAnswerDelay)
   // 行间逐行错开（--i * --row-gap）
   const secondRowDelay = parseFloat(
     await page

--- a/tests/unit/hero-terminal.test.ts
+++ b/tests/unit/hero-terminal.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeTurnTimings, type TerminalTurn } from '../../src/components/HeroTerminal.tsx'
+
+/**
+ * issue #40：hero 终端演出编排——computeTurnTimings 纯函数契约。
+ * 每轮：输入框逐字符打字（typeStart → typeStart + typeDuration）→ 发送
+ * （sendTime：问题进入 transcript + 输入框清空同一时刻）→ 状态行
+ * （Thinking… → Done.）→ 回答行；轮次严格串行（下一轮打字不早于上一轮
+ * 最后一行揭示）；停驻光标在末轮发送后出现；演出总时长覆盖最后一行揭示。
+ * 全部时刻由数据驱动（问题字符数 × 打字速度 + 节奏参数），新增轮次无需改代码。
+ */
+
+/** 测试剧本：三轮问答（你是谁 / 这个站有什么 / 怎么联系），含状态行与回答行 */
+function script(): TerminalTurn[] {
+  return [
+    {
+      question: '你是谁',
+      lines: [
+        { text: 'Thinking…', status: 'thinking' },
+        { text: 'Done.', status: 'done' },
+        { text: '前端工程师 · 关注 Web 生态与工程化' },
+        { text: '了解真相，才能获得真正的自由', typewriter: true },
+      ],
+    },
+    {
+      question: '这个站有什么',
+      lines: [
+        { text: 'Thinking…', status: 'thinking' },
+        { text: 'Done.', status: 'done' },
+        { text: '3 篇文章 · 4 个标签' },
+      ],
+    },
+    {
+      question: '怎么联系',
+      lines: [
+        { text: 'Thinking…', status: 'thinking' },
+        { text: 'Done.', status: 'done' },
+        { text: 'https://github.com/hacxy' },
+      ],
+    },
+  ]
+}
+
+describe('computeTurnTimings（issue #40 演出编排）', () => {
+  it('每轮：打字在发送前完成，发送 = 问题进入 transcript 时刻，随后 Thinking… → Done. → 回答', () => {
+    const timeline = computeTurnTimings(script())
+    const [round] = timeline.rounds
+
+    // 打字窗口：typeStart 开始、持续 typeDuration，发送在其后（打字完成后停顿）
+    expect(round!.typeStart).toBeGreaterThanOrEqual(0)
+    expect(round!.typeDuration).toBeGreaterThan(0)
+    expect(round!.sendTime).toBeGreaterThan(round!.typeStart + round!.typeDuration)
+
+    // 输出行揭示时刻严格递增，且全部晚于发送（问题先进 transcript，再出状态行/回答）
+    for (let i = 1; i < round!.lineTimes.length; i++) {
+      expect(round!.lineTimes[i]!).toBeGreaterThan(round!.lineTimes[i - 1]!)
+    }
+    for (const t of round!.lineTimes) {
+      expect(t).toBeGreaterThan(round!.sendTime)
+    }
+
+    // 状态行顺序：Thinking… 先于 Done.；回答行在状态行之后
+    const [thinking, done, answer] = round!.lineTimes
+    expect(done!).toBeGreaterThan(thinking!)
+    expect(answer!).toBeGreaterThan(done!)
+  })
+
+  it('轮次严格串行：下一轮打字不早于上一轮最后一行揭示（真实会话顺序）', () => {
+    const timeline = computeTurnTimings(script())
+    const [r0, r1, r2] = timeline.rounds
+
+    expect(r1!.typeStart).toBeGreaterThan(r0!.lineTimes[r0!.lineTimes.length - 1]!)
+    expect(r2!.typeStart).toBeGreaterThan(r1!.lineTimes[r1!.lineTimes.length - 1]!)
+  })
+
+  it('停驻光标在末轮发送后出现；演出总时长覆盖最后一行揭示完成', () => {
+    const timeline = computeTurnTimings(script())
+    const last = timeline.rounds[timeline.rounds.length - 1]!
+
+    // 末轮发送后输入框清空（停驻态），光标随之出现并持续闪烁
+    expect(timeline.parkedDelay).toBeGreaterThan(last.sendTime)
+    // 演出总时长 ≥ 最后一行揭示完成时刻（不循环，播完停驻最终态）
+    expect(timeline.showEnd).toBeGreaterThanOrEqual(last.lineTimes[last.lineTimes.length - 1]!)
+  })
+
+  it('数据驱动：新增轮次自动延长演出，渲染代码零改动', () => {
+    const three = computeTurnTimings(script())
+    const four = computeTurnTimings([
+      ...script(),
+      {
+        question: '新增问题',
+        lines: [
+          { text: 'Thinking…', status: 'thinking' },
+          { text: 'Done.', status: 'done' },
+          { text: '新增回答' },
+        ],
+      },
+    ])
+
+    // 演出总时长随轮次增加而变长；已有轮次时刻不受影响（纯派生，无共享可变状态）
+    expect(four.showEnd).toBeGreaterThan(three.showEnd)
+    for (let i = 0; i < three.rounds.length; i++) {
+      expect(four.rounds[i]!.typeStart).toBe(three.rounds[i]!.typeStart)
+      expect(four.rounds[i]!.sendTime).toBe(three.rounds[i]!.sendTime)
+      expect(four.rounds[i]!.lineTimes).toEqual(three.rounds[i]!.lineTimes)
+    }
+  })
+})


### PR DESCRIPTION
Closes #40\n\nImplemented by the pi-afk agent.