### PR TITLE
全站链接与顶部导航 hover/focus 去背景化（颜色+下划线取代反白）

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,8 @@
 /* 设计基调：正文 = 系统无衬线栈（PingFang SC / Microsoft YaHei / Noto Sans SC）；
    代码与元数据 = JetBrains Mono；全站配色为纯黑白灰阶（issue #17）：
    亮色 = 白底黑字 + 灰阶过渡，暗色 = 黑底白字反色，无任何彩色系残留。
-   链接不再依赖颜色区分（见 @layer base 全站链接样式）：下划线 + 加粗 + hover 反白。 */
+   链接不再依赖颜色区分（见 @layer base 全站链接样式）：下划线 + 加粗，
+   hover/focus 背景保持透明 + 颜色/下划线反馈（issue #52，不再黑白反白块）。 */
 @theme {
   --font-sans:
     system-ui, -apple-system, 'PingFang SC', 'Microsoft YaHei', 'Noto Sans SC', sans-serif;
@@ -82,24 +83,37 @@ html.dark {
   body {
     font-family: var(--font-sans);
   }
-  /* 全站链接样式（issue #17）：下划线 + 加粗 + hover 反白，不再依赖颜色区分；
+  /* 全站链接样式（issue #17）：下划线 + 加粗，不再依赖颜色区分；
+     hover / focus-visible（issue #52）：背景保持透明（不再黑白反白块），
+     颜色变 accent + 下划线（页脚等 muted 上下文可见颜色变化；灰阶下 accent
+     与正文同色属设计系统固有，下划线/加粗承担主要反馈）。键盘 Tab 聚焦与
+     鼠标 hover 同一视觉机制。
      导航高亮沿用同一机制：active 导航项 = 加粗 + 下划线（见 .site-nav a.nav-active）。
      例外：文章列表行（.post-row）为终端输出行形态——常规字重、无下划线，
-     hover/键盘焦点反白沿用同一 accent 令牌机制。 */
+     hover/键盘焦点仅标题 accent + 下划线（issue #25，见下）。 */
   a {
     font-weight: 700;
     text-decoration: underline;
     text-underline-offset: 3px;
   }
-  a:hover {
-    background-color: var(--color-accent);
-    color: var(--color-accent-contrast);
+  a:hover,
+  a:focus-visible {
+    background-color: transparent;
+    color: var(--color-accent);
   }
-  /* 顶部导航：菜单项为普通文本外观（不加粗、无下划线），
-     active 项用链接机制高亮（加粗 + 下划线） */
+  /* 顶部导航：菜单项为普通文本外观（不加粗、无下划线）；
+     hover/focus（issue #52）= 加粗 + 下划线 + accent 色（与 active 高亮
+     同一视觉机制，无背景色块）；active 项用链接机制高亮（加粗 + 下划线） */
   .site-nav a {
     font-weight: 400;
     text-decoration: none;
+  }
+  .site-nav a:hover,
+  .site-nav a:focus-visible {
+    background-color: transparent;
+    color: var(--color-accent);
+    font-weight: 700;
+    text-decoration: underline;
   }
   .site-nav a.nav-active {
     font-weight: 700;
@@ -466,8 +480,10 @@ html.dark .bg-texture {
   }
 }
 
-/* 终端内链接 hover：恒黑底终端自闭环（白底黑字反白），与页面 chrome 主题解耦 */
-.hero-terminal a:hover {
+/* 终端内链接 hover/focus：恒黑底终端自闭环（白底黑字反白），与页面 chrome 主题解耦
+   （issue #52：全站链接去反白后，终端自闭环反白保留，focus 与 hover 同一视觉机制） */
+.hero-terminal a:hover,
+.hero-terminal a:focus-visible {
   background-color: #fff;
   color: #000;
 }
@@ -535,7 +551,8 @@ html.dark .terminal-dot--green {
 /* 整行为单个链接：mono 日期 + 标题 + #标签（终端 ls 输出行形态）；
    hover / 键盘 focus-visible 反馈（issue #25）：行首沟槽淡入「>」终端提示符 +
    标题 accent 色 + 下划线（字重保持 400），日期/标签保持 muted，
-   整行背景不再黑白反转（全站链接反白机制为文章行特例豁免）；
+   整行背景保持透明、文字保持继承色（issue #52 全站链接去反白后，文章行豁免仍生效：
+   行自身不接受 accent 整行染色，仅标题 accent + 下划线）；
    行内不渲染摘要（内容管线保留 description，文章页/SEO 继续使用） */
 .post-row {
   display: flex;
@@ -565,8 +582,8 @@ html.dark .terminal-dot--green {
   opacity: 1;
 }
 
-/* hover/focus 时整行豁免全站 a:hover 反白（背景保持透明、文字保持继承色），
-   与页面 chrome 链接的反白机制解耦 */
+/* hover/focus 时整行豁免全站 a:hover/a:focus-visible 的 accent 染色
+   （背景保持透明、文字保持继承色），仅标题经子选择器变 accent + 下划线 */
 .post-row:hover,
 .post-row:focus-visible {
   background-color: transparent;
@@ -710,7 +727,7 @@ html.dark .terminal-dot--green {
 
 /* 文件夹行：按钮形态（非链接），行布局与 .post-row 同构（折叠标记 + mono 名）；
    常规字重、muted 灰（结构层弱于文章标题），hover/键盘焦点 accent + 下划线，
-   背景不反白（与文章行同一豁免） */
+   背景保持透明（与文章行同一豁免，不出现色块） */
 .post-tree-folder {
   display: flex;
   align-items: baseline;
@@ -796,14 +813,15 @@ html.dark .terminal-dot--green {
 }
 
 /* 目录链接：普通文本外观（不加粗、无下划线，与顶部导航同机制），
-   hover 弱化下划线；active（当前章节，scroll-spy）加粗 + 下划线——
+   hover/focus 加下划线；active（当前章节，scroll-spy）加粗 + 下划线——
    全站导航高亮同一机制（.site-nav a.nav-active） */
 .post-toc a {
   font-weight: 400;
   text-decoration: none;
   color: var(--color-muted);
 }
-.post-toc a:hover {
+.post-toc a:hover,
+.post-toc a:focus-visible {
   background-color: transparent;
   color: var(--color-accent);
   text-decoration: underline;
@@ -852,8 +870,8 @@ html.dark .terminal-dot--green {
   }
 }
 
-/* 触发按钮：终端风格（mono + 边框 + 灰底），hover 反白与全站交互一致；
-   打开的抽屉对应按钮加粗 + 下划线（沿用导航高亮机制） */
+/* 触发按钮：终端风格（mono + 边框 + 灰底），hover/focus 反白与全站交互一致
+   （键盘 Tab 与鼠标 hover 同一视觉机制，issue #52） */
 .drawer-trigger {
   align-items: center;
   padding: 0.25rem 0.75rem;
@@ -865,7 +883,8 @@ html.dark .terminal-dot--green {
   line-height: 1.5;
   color: var(--color-accent);
 }
-.drawer-trigger:hover {
+.drawer-trigger:hover,
+.drawer-trigger:focus-visible {
   background-color: var(--color-accent);
   color: var(--color-accent-contrast);
 }
@@ -943,7 +962,7 @@ html.dark .drawer-panel {
   }
 }
 
-/* 关闭按钮：面板右上角（flex 列末尾右对齐）；hover 反白 */
+/* 关闭按钮：面板右上角（flex 列末尾右对齐）；hover/focus 反白（与鼠标一致） */
 .drawer-close {
   align-self: flex-end;
   width: 2rem;
@@ -956,7 +975,8 @@ html.dark .drawer-panel {
   line-height: 1;
   color: var(--color-accent);
 }
-.drawer-close:hover {
+.drawer-close:hover,
+.drawer-close:focus-visible {
   background-color: var(--color-accent);
   color: var(--color-accent-contrast);
 }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -975,7 +975,7 @@ test('prerendered HTML ships the inline no-flash theme script', async ({ request
   expect(html).toContain('prefers-color-scheme')
 })
 
-test('geek-style design: mono fonts; links are bold+underline with inverted hover, nav active shares mechanism', async ({
+test('geek-style design: mono fonts; links are bold+underline with transparent hover (color+underline), nav active shares mechanism', async ({
   page,
 }) => {
   await page.goto('/')
@@ -997,7 +997,7 @@ test('geek-style design: mono fonts; links are bold+underline with inverted hove
   await expect(page.locator('html')).toHaveCSS('color', 'rgb(26, 26, 26)')
 
   // 全站链接样式 = 下划线 + 加粗（不再依赖颜色区分：链接与同上下文文本同色）
-  // 页脚链接继承 footer 的 muted 灰（与页脚正文同色），hover 反白用 accent 令牌覆盖
+  // 页脚链接继承 footer 的 muted 灰（与页脚正文同色），hover 用 accent 令牌覆盖
   const ccLink = page.getByRole('link', { name: 'CC BY-NC-SA 4.0' })
   expect(await ccLink.evaluate((el) => getComputedStyle(el).fontWeight)).toBe('700')
   expect(await ccLink.evaluate((el) => getComputedStyle(el).textDecorationLine)).toContain(
@@ -1005,23 +1005,40 @@ test('geek-style design: mono fonts; links are bold+underline with inverted hove
   )
   expect(await ccLink.evaluate((el) => getComputedStyle(el).color)).toBe('rgb(102, 102, 102)')
 
-  // hover 反白：亮色 = 黑底白字
+  // hover（issue #52）：背景保持透明（不再黑白反白块）、颜色变 accent（亮色近黑）、
+  // 下划线保留；muted 灰 → accent 为页脚链接可见的 hover 反馈
   await ccLink.hover()
-  await expect(ccLink).toHaveCSS('background-color', 'rgb(26, 26, 26)')
-  await expect(ccLink).toHaveCSS('color', 'rgb(255, 255, 255)')
+  await expect(ccLink).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+  await expect(ccLink).toHaveCSS('color', 'rgb(26, 26, 26)')
+  await expect(ccLink).toHaveCSS('text-decoration-line', 'underline')
 
-  // 暗色 = 黑底白字反色（背景近黑、文字近白），hover 反白 = 白底黑字
+  // 顶部导航 hover（issue #52）：加粗 + 下划线 + accent 色，无背景色块；
+  // 灰阶下 accent 与正文同色属设计系统固有，加粗/下划线承担主要反馈。
+  // 悬停非 active 的「关于」（首页当前页 = 文章，避免与 nav-active 混淆）
+  const aboutNav = page.getByRole('link', { name: '关于' })
+  await aboutNav.hover()
+  await expect(aboutNav).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+  await expect(aboutNav).toHaveCSS('color', 'rgb(26, 26, 26)')
+  await expect(aboutNav).toHaveCSS('font-weight', '700')
+  await expect(aboutNav).toHaveCSS('text-decoration-line', 'underline')
+
+  // 暗色 = 黑底白字反色（背景近黑、文字近白），同一机制：hover 背景透明 + accent（近白）
   await page.getByRole('button', { name: '切换暗色模式' }).click()
   await expect(page.locator('html')).toHaveCSS('background-color', 'rgb(10, 10, 10)')
   await expect(page.locator('html')).toHaveCSS('color', 'rgb(230, 230, 230)')
   await ccLink.hover()
-  await expect(ccLink).toHaveCSS('background-color', 'rgb(230, 230, 230)')
-  await expect(ccLink).toHaveCSS('color', 'rgb(0, 0, 0)')
+  await expect(ccLink).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+  await expect(ccLink).toHaveCSS('color', 'rgb(230, 230, 230)')
+  await expect(ccLink).toHaveCSS('text-decoration-line', 'underline')
+  await aboutNav.hover()
+  await expect(aboutNav).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+  await expect(aboutNav).toHaveCSS('color', 'rgb(230, 230, 230)')
+  await expect(aboutNav).toHaveCSS('font-weight', '700')
+  await expect(aboutNav).toHaveCSS('text-decoration-line', 'underline')
 
   // 导航高亮沿用同一机制（加粗 + 下划线，不再依赖颜色区分）
-  await page.getByRole('link', { name: '关于' }).click()
+  await aboutNav.click()
   await expect(page).toHaveURL(/\/about/)
-  const aboutNav = page.getByRole('link', { name: '关于' })
   await expect(aboutNav).toHaveClass(/nav-active/)
   expect(await aboutNav.evaluate((el) => getComputedStyle(el).fontWeight)).toBe('700')
   expect(await aboutNav.evaluate((el) => getComputedStyle(el).textDecorationLine)).toContain(
@@ -1033,6 +1050,58 @@ test('geek-style design: mono fonts; links are bold+underline with inverted hove
   expect(await postsNav.evaluate((el) => getComputedStyle(el).textDecorationLine)).not.toContain(
     'underline',
   )
+})
+
+test('nav & footer links focus-visible matches hover: transparent bg + accent color + underline + bold (keyboard Tab, issue #52)', async ({
+  page,
+}) => {
+  await page.goto('/')
+
+  // 归一化亮色（focus-visible 颜色断言用）后重置焦点（主题切换点击会聚焦按钮，
+  // 否则后续 Tab 链整体偏移一位）
+  const html = page.locator('html')
+  if (((await html.getAttribute('class')) ?? '').includes('dark')) {
+    await page.getByRole('button', { name: '切换暗色模式' }).click()
+  }
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur?.())
+
+  // 等水合完成（点阵 canvas 仅客户端挂载）再按 Tab，避免快速 Tab 落在水合期间被吞
+  await expect(page.locator('canvas.bg-dots')).toHaveCount(1)
+
+  // 基线：首页非 active 的「关于」导航项为普通文本外观（无下划线、不加粗）
+  const aboutNav = page.getByRole('link', { name: '关于' })
+  await expect(aboutNav).toHaveCSS('font-weight', '400')
+  await expect(aboutNav).toHaveCSS('text-decoration-line', 'none')
+
+  // Tab 1 → 「文章」导航项（首页 active 项，加粗/下划线既有；背景/颜色不回归）
+  await page.keyboard.press('Tab')
+  const postsNav = page.getByRole('link', { name: '文章', exact: true })
+  await expect(postsNav).toBeFocused()
+  await expect(postsNav).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+
+  // Tab 2 → 「关于」导航项（非 active）：focus-visible 与 hover 同一视觉机制
+  // （背景透明 + accent 色 + 加粗 + 下划线，无背景色块）
+  await page.keyboard.press('Tab')
+  await expect(aboutNav).toBeFocused()
+  await expect(aboutNav).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+  await expect(aboutNav).toHaveCSS('color', 'rgb(26, 26, 26)')
+  await expect(aboutNav).toHaveCSS('font-weight', '700')
+  await expect(aboutNav).toHaveCSS('text-decoration-line', 'underline')
+
+  // 页脚 CC 链接：Tab 顺延至页脚（主题 → GitHub → RSS → hero GitHub 外链 →
+  // 全部文章行 → CC），焦点反馈与 hover 一致（背景透明 + accent 色 + 下划线 + 加粗）。
+  // 不硬编码 Tab 次数（正常链路 = 距「关于」5 + 文章行数）：逐次 Tab 至 CC 聚焦即停，
+  // 上限多加 30 次防真回归死循环；中途新增可聚焦项不破坏本用例
+  const ccLink = page.getByRole('link', { name: 'CC BY-NC-SA 4.0' })
+  for (let i = 0; i < publishedPosts().length + 30; i++) {
+    await page.keyboard.press('Tab')
+    if (await ccLink.evaluate((el) => el === document.activeElement)) break
+  }
+  await expect(ccLink).toBeFocused()
+  await expect(ccLink).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+  await expect(ccLink).toHaveCSS('color', 'rgb(26, 26, 26)')
+  await expect(ccLink).toHaveCSS('text-decoration-line', 'underline')
+  await expect(ccLink).toHaveCSS('font-weight', '700')
 })
 
 test('fonts are self-hosted: woff2 on same origin, no external font requests', async ({


### PR DESCRIPTION
Closes #52

## 要构建什么

从访客视角：悬停「文章 / 关于」导航项、正文链接或页脚链接时，页面不再出现背景反白色块（亮色=黑底白字、暗色=白底黑字），而是透明背景 + 颜色变化 + 下划线；顶部导航项悬停时加粗 + 下划线 + accent 色（与当前页高亮同一视觉机制，纯灰阶下颜色变化不可见属设计系统固有，加粗/下划线承担主要反馈）。

键盘用户按 Tab 聚焦链接/按钮时获得与鼠标 hover 一致的视觉反馈（颜色 / 下划线）。

既有已豁免反白的上下文（文章行 / 目录树文件夹 / TOC）保持现状不动。

## 验收标准

- [ ] 全站链接（正文 / 页脚）hover 时背景透明，不再出现背景反白
- [ ] 顶部导航项 hover 时加粗 + 下划线 + accent 色，无背景色块
- [ ] 链接 focus-visible（键盘 Tab）与 hover 同一视觉机制
- [ ] 既有豁免上下文（文章行 / 目录树 / TOC）的 hover 行为零回归
- [ ] e2e 计算样式断言覆盖：导航项、页脚链接、focus-visible（背景透明、颜色、下划线、字重），既有「geek-style」用例的 hover 断言同步更新

## 阻塞于

无——可以直接开工