### PR TITLE
终端块状光标几何对齐（高度 1em + 字形中线垂直居中）

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -311,8 +311,10 @@ html.dark .bg-texture {
 /* 打字机文本（纯 CSS）：完整文本始终在 DOM（SEO / reduced-motion / 结束态直接可见），
    动画用 clip-path 从右向左裁切 + steps(字符数) 逐字符揭示；
    --type-chars / --type-duration / --delay 由组件按数据驱动（issue #40：
-   打字机机制从行内揭示扩展到输入框内逐字符打字，见 .terminal-typed） */
+   打字机机制从行内揭示扩展到输入框内逐字符打字，见 .terminal-typed）；
+   position: relative 为行内光标提供定位基准（issue #53，见 .terminal-cursor） */
 .typewriter-text {
+  position: relative;
   display: inline-block;
   clip-path: inset(0 0 0 0);
   animation-name: terminal-typing;
@@ -330,14 +332,25 @@ html.dark .bg-texture {
   }
 }
 
-/* 块状闪烁光标：打字机行尾（终端「正在输出」状态） */
-.terminal-cursor {
-  display: inline-block;
+/* 块状光标几何（issue #53）：打字机行尾行内光标与输入框停驻光标共用同一套规则——
+   高度 = 字形高度（1em）、以字形中线为基准垂直居中，不遮文字：
+   - 行内 .terminal-cursor：绝对定位于文字容器（.typewriter-text / .terminal-typed，
+     容器高度 = 行框高 = line-height），top 50% + translateY(-50%) ⇒ 垂直中心 =
+     行框中心 = 字形中线（与相邻文字块 rect 中心重合，不依赖字体度量）
+   - 停驻 .terminal-input-cursor：top = padding-top + 半行高余量（见输入区） */
+.terminal-cursor,
+.terminal-input-cursor {
   width: 0.55em;
-  height: 1.05em;
-  margin-left: 0.1em;
-  vertical-align: text-bottom;
+  height: 1em;
   background: #fff;
+}
+/* 行内块状闪烁光标：打字机行尾（终端「正在输出」状态）与输入框打字光标；
+   跟随文字末尾（容器右端 + 0.1em 间距），随容器 clip-path 一起逐字符揭示 */
+.terminal-cursor {
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 0.1em);
+  transform: translateY(-50%);
   animation: terminal-blink 1.1s steps(1) infinite;
 }
 @keyframes terminal-blink {
@@ -371,18 +384,22 @@ html.dark .bg-texture {
   padding: 0 1rem 0.75rem;
 }
 .terminal-input {
+  /* 输入槽位参数（issue #53）：停驻光标按「padding-top + 半行高余量」公式对齐文字行，
+     padding/行高在此单一定义、槽位与光标共用（.terminal-typed / .terminal-input-cursor） */
+  --input-pad-y: 0.4rem;
+  --input-line-height: 1.5;
   position: relative;
   min-height: 2.1rem;
   border: 1px solid #3a3a3a;
   border-radius: 0.25rem;
   background: #0d0d0d;
-  padding: 0.4rem 0.625rem;
+  padding: var(--input-pad-y) 0.625rem;
   font-size: 0.875rem;
-  line-height: 1.5;
+  line-height: var(--input-line-height);
 }
 .terminal-typed {
   position: absolute;
-  top: 0.4rem;
+  top: var(--input-pad-y);
   left: 0.625rem;
   white-space: nowrap;
   /* 基础态完整可见（reduced-motion / 无动画时输入框直接显示全文） */
@@ -408,15 +425,14 @@ html.dark .bg-texture {
   }
 }
 /* 停驻光标：clip 隐藏直到 --delay-appear（末轮发送后），随后块状闪烁继续
-   （块状视觉与行内 .terminal-cursor 同一形态：白块 + 闪烁） */
+   （块状视觉与行内 .terminal-cursor 同一形态：白块 + 闪烁，几何规则见 .terminal-cursor
+   共用块——高度 1em、以字形中线垂直居中） */
 .terminal-input-cursor {
   position: absolute;
-  top: 0.4rem;
+  /* 对齐文字行：padding-top + 半行高余量（(line-height − 1em)/2，line-height 1.5
+     ⇒ 0.25em）——以字形中线为基准垂直居中，不再从 padding 顶边起算 */
+  top: calc(var(--input-pad-y) + (var(--input-line-height) - 1) * 0.5em);
   left: 0.625rem;
-  display: inline-block;
-  width: 0.55em;
-  height: 1.05em;
-  background: #fff;
   clip-path: inset(0 0 0 0);
   animation:
     terminal-blink 1.1s steps(1) infinite,

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -477,6 +477,45 @@ test('hero terminal: reduced-motion skips all animations, full text visible, no 
   expect(pageErrors).toHaveLength(0)
 })
 
+test('hero terminal: block cursors share one geometry — glyph height (1em), centered on glyph midline (issue #53)', async ({
+  page,
+}) => {
+  await page.goto('/')
+  const terminal = page.locator('.hero-terminal')
+
+  // 几何助手：getBoundingClientRect → 顶/底/垂直中心/高度（像素浮点）
+  const rect = (el: Element) => {
+    const r = el.getBoundingClientRect()
+    return { top: r.top, bottom: r.bottom, center: (r.top + r.bottom) / 2, height: r.height }
+  }
+
+  // 输出行行内光标（打字机行尾）：高度 = 字形高度（1em），垂直中心 = 相邻文字块
+  // 垂直中心（绝对定位于文字容器：top 50% + translateY(-50%) ⇒ 行框中心 = 字形中线）
+  const lineCursor = terminal.locator('.typewriter-text > .terminal-cursor')
+  const lineText = terminal.locator('.typewriter-text')
+  const lineFontSize = parseFloat(await lineText.evaluate((el) => getComputedStyle(el).fontSize))
+  const [cLine, tLine] = await Promise.all([lineCursor.evaluate(rect), lineText.evaluate(rect)])
+  expect(Math.abs(cLine.center - tLine.center)).toBeLessThan(1)
+  expect(Math.abs(cLine.height - lineFontSize)).toBeLessThan(0.5)
+  // 光标垂直范围落在文字行内（不遮住上下相邻行文字）
+  expect(cLine.top).toBeGreaterThanOrEqual(tLine.top - 1)
+  expect(cLine.bottom).toBeLessThanOrEqual(tLine.bottom + 1)
+
+  // 输入框停驻光标：同一几何规则——top = padding-top + 半行高余量（对齐文字行，
+  // 不再从 padding 顶边起算），垂直中心与输入框文字块一致、高度 = 字形高度
+  const parked = terminal.locator('.terminal-input-cursor')
+  const inputText = terminal.locator('.terminal-input-text').first()
+  const inputFontSize = parseFloat(await inputText.evaluate((el) => getComputedStyle(el).fontSize))
+  const [cParked, tInput] = await Promise.all([parked.evaluate(rect), inputText.evaluate(rect)])
+  expect(Math.abs(cParked.center - tInput.center)).toBeLessThan(1)
+  expect(Math.abs(cParked.height - inputFontSize)).toBeLessThan(0.5)
+  expect(cParked.top).toBeGreaterThanOrEqual(tInput.top - 1)
+  expect(cParked.bottom).toBeLessThanOrEqual(tInput.bottom + 1)
+
+  // 两处光标高度一致（共用同一套几何规则：高度 1em、字形中线垂直居中）
+  expect(Math.abs(cParked.height - cLine.height)).toBeLessThan(0.5)
+})
+
 test('post list: terminal output lines show mono date, title and #tags (no description)', async ({
   page,
 }) => {


### PR DESCRIPTION
Closes #53

## 要构建什么

从访客视角：hero 终端演出中，块状光标（输入框停驻光标与上方 AI 输出打字机行的行内光标）不再遮住文字、且与文字垂直居中对齐——高度收敛为字形高度（1em）、以字形中线为基准垂直居中，两处表现一致（共用同一套规则），观感整齐。

## 验收标准

- [ ] 输出行行内光标与输入框停驻光标共用同一套几何规则（高度 1em、字形中线垂直居中）
- [ ] 输入框停驻光标按「padding-top + 半行高余量」公式对齐文字行，不再从 padding 顶边起算
- [ ] 光标不遮挡文字（与相邻文字块垂直中心一致、高度一致）
- [ ] e2e 用 getBoundingClientRect 几何断言：光标与相邻文字块的垂直中心一致、高度一致（沿用现有 e2e 断言风格）
- [ ] reduced-motion 下行为与现状一致（光标静止/隐藏逻辑不回归）

## 阻塞于

无——可以直接开工