### PR TITLE
主题切换按钮：动作语义图标（太阳/月亮）+ 整页过渡动画

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,14 @@
         }
       })()
     </script>
+    <script>
+      // 主题过渡标记（issue #54）：支持 View Transitions API 时给 <html> 挂 .theme-vt。
+      // CSS 以标记门控——标记存在时整页交叉淡化交给 View Transition（禁用 CSS 过渡，
+      // 不双重动画）；无标记（不支持该 API）时 CSS 过渡兜底。首帧前执行，避免切换瞬间样式闪跳。
+      if (document.startViewTransition) {
+        document.documentElement.classList.add('theme-vt')
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/icons.svg
+++ b/public/icons.svg
@@ -1,4 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg">
+  <symbol id="moon-icon" viewBox="0 0 24 24">
+    <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </symbol>
+  <symbol id="sun-icon" viewBox="0 0 24 24">
+    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+      <circle cx="12" cy="12" r="4"/>
+      <path d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32 1.41 1.41M2 12h2m16 0h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+    </g>
+  </symbol>
   <symbol id="bluesky-icon" viewBox="0 0 16 17">
     <g clip-path="url(#bluesky-clip)"><path fill="#08060d" d="M7.75 7.735c-.693-1.348-2.58-3.86-4.334-5.097-1.68-1.187-2.32-.981-2.74-.79C.188 2.065.1 2.812.1 3.251s.241 3.602.398 4.13c.52 1.744 2.367 2.333 4.07 2.145-2.495.37-4.71 1.278-1.805 4.512 3.196 3.309 4.38-.71 4.987-2.746.608 2.036 1.307 5.91 4.93 2.746 2.72-2.746.747-4.143-1.747-4.512 1.702.189 3.55-.4 4.07-2.145.156-.528.397-3.691.397-4.13s-.088-1.186-.575-1.406c-.42-.19-1.06-.395-2.741.79-1.755 1.24-3.64 3.752-4.334 5.099"/></g>
     <defs><clipPath id="bluesky-clip"><path fill="#fff" d="M.1.85h15.3v15.3H.1z"/></clipPath></defs>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,21 +1,60 @@
+import { useSyncExternalStore } from 'react'
+
+import Icon from './Icon.tsx'
+
 /**
- * 暗色模式切换：直接翻转 <html> 的 .dark class 并记忆偏好到 localStorage。
- * 无内部状态——按钮内容不依赖主题，SSR 与客户端输出一致，杜绝 hydration mismatch；
- * 当前主题的视觉反馈由 CSS（dark: variant）承担。
+ * 暗色模式切换（issue #54）：动作语义图标 + 整页过渡。
+ * - 图标按当前主题渲染动作语义：亮色 = 月亮（点击进入暗色）、暗色 = 太阳（点击进入亮色），
+ *   一眼看出切换后进入的主题；currentColor 线性符号（icons.svg 精灵），颜色 = --color-accent
+ *   （亮色近黑 / 暗色近白，随主题灰阶自动反色，与导航 GitHub/RSS 图标同一视觉层级）
+ * - 当前主题经 useSyncExternalStore 观察 <html> 的 .dark class（MutationObserver）：
+ *   服务端快照恒为亮色（确定性输出 = moon），水合后更新为实际主题——与 BackgroundDots
+ *   同一快照机制，杜绝 hydration mismatch（SSR 与客户端首帧输出一致）
+ * - 点击切换：支持 View Transitions API 且非 prefers-reduced-motion 时，class 切换被
+ *   startViewTransition 包裹（整页交叉淡化，背景纹理与点阵 canvas 均被快照覆盖）；
+ *   不支持该 API 的浏览器直接切换 + CSS 过渡兜底（见 index.css，html 标记类门控），
+ *   reduce 用户瞬时切换（JS 侧跳过过渡）
+ * - aria-label「切换暗色模式」与 localStorage 记忆逻辑保持不变（既有 e2e/无障碍依赖不回归）
  */
+
+/** 观察 <html> 是否带 .dark：订阅 class 属性变更；服务端快照恒 false（确定性输出） */
+function useIsDark(): boolean {
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      const observer = new MutationObserver(onStoreChange)
+      observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+      return () => observer.disconnect()
+    },
+    () => document.documentElement.classList.contains('dark'),
+    () => false,
+  )
+}
+
 export default function ThemeToggle() {
+  const dark = useIsDark()
+
+  const toggle = () => {
+    const root = document.documentElement
+    const next = !root.classList.contains('dark')
+    // class 切换 + 记忆：放同一闭包，View Transition 回调内执行（旧快照先被捕获）
+    const apply = () => {
+      root.classList.toggle('dark', next)
+      localStorage.setItem('theme', next ? 'dark' : 'light')
+    }
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (document.startViewTransition && !reducedMotion) {
+      const vt = document.startViewTransition(apply)
+      vt.finished.catch(() => {
+        /* 过渡被中断（如快速连续点击/导航离开）时静默忽略 */
+      })
+    } else {
+      apply()
+    }
+  }
+
   return (
-    <button
-      type="button"
-      aria-label="切换暗色模式"
-      onClick={() => {
-        const root = document.documentElement
-        const next = !root.classList.contains('dark')
-        root.classList.toggle('dark', next)
-        localStorage.setItem('theme', next ? 'dark' : 'light')
-      }}
-    >
-      主题
+    <button type="button" aria-label="切换暗色模式" className="theme-toggle" onClick={toggle}>
+      <Icon name={dark ? 'sun-icon' : 'moon-icon'} />
     </button>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -192,6 +192,39 @@ html.dark .bg-texture {
   pointer-events: none;
 }
 
+/* ===== 主题切换按钮与过渡（issue #54） ===== */
+
+/* 图标按钮：月亮（亮色，点击进入暗色）/ 太阳（暗色，点击进入亮色）——动作语义
+   图标（一眼看出切换后进入的主题）；currentColor 线性符号（icons.svg 精灵），
+   颜色 = --color-accent（亮色近黑 / 暗色近白，随主题灰阶自动反色），与导航
+   GitHub/RSS 图标同一视觉层级；hover/focus 无背景色块（issue #52 机制） */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  color: var(--color-accent);
+  cursor: pointer;
+}
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  background-color: transparent;
+  color: var(--color-accent);
+}
+
+/* 主题切换过渡：支持 View Transitions API 的浏览器由入口脚本给 <html> 挂 .theme-vt
+   标记类（见 index.html）——整页交叉淡化交给 View Transition（旧/新快照交叉淡化，
+   背景纹理与点阵 canvas 均被快照覆盖），此时禁用 CSS 过渡（不双重动画）；
+   无标记（不支持该 API）时 CSS 过渡兜底——html 背景/文字颜色平滑渐变
+   （color 为继承属性，正文各元素随 html 动画值逐帧跟随）。
+   prefers-reduced-motion：JS 侧跳过 View Transition、CSS 侧禁用过渡（见底部 reduce 块） */
+html:not(.theme-vt) {
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
+}
+
 /* ===== hero 终端（issue #18）：pi.dev 风格 AI 会话演出 ===== */
 
 /* hero 区入场动画：克制（淡入 + 轻微上移 8px，纯 CSS） */
@@ -1170,5 +1203,9 @@ html.dark .drawer-panel {
   .drawer-overlay,
   .drawer-panel {
     animation: none;
+  }
+  /* 主题切换过渡兜底：reduce 下禁用（瞬时切换，issue #54） */
+  html:not(.theme-vt) {
+    transition: none;
   }
 }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -460,7 +460,11 @@ test('clicking a post row opens the post page (whole row is clickable)', async (
 test('post row hover feedback: terminal prompt fades in + title underline, no background inversion (light & dark)', async ({
   page,
 }) => {
+  // issue #54：禁用平滑滚动——主题切换点击时 Playwright 会把滚动条平滑滚回顶部（按钮在顶部），
+  // 与后续 hover() 的滚动/VT 竞态，导致行漂出鼠标下方。本用例只验证 hover 视觉反馈，
+  // 不禁滚动不影响断言语义（真实鼠标不受此影响）。须在 goto 之后注入（导航会清除注入样式）
   await page.goto('/')
+  await page.addStyleTag({ content: 'html { scroll-behavior: auto !important; }' })
   const row = page.locator('.post-row').first()
   const prompt = row.locator('.post-row-prompt')
   const title = row.locator('.post-row-title')
@@ -886,13 +890,132 @@ test('dark mode toggles via button and persists after reload', async ({ page }) 
   const initialDark = ((await html.getAttribute('class')) ?? '').includes('dark')
 
   await page.getByRole('button', { name: '切换暗色模式' }).click()
-  const afterDark = ((await html.getAttribute('class')) ?? '').includes('dark')
-  expect(afterDark).not.toBe(initialDark)
+  // issue #54：class 切换在 startViewTransition 回调内异步执行（整页交叉淡化），
+  // 用轮询等待翻转（同一用例断言，适配异步过渡机制，不改变验收语义）
+  const afterDark = !initialDark
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.classList.contains('dark')))
+    .toBe(afterDark)
 
   // 刷新后偏好保持（inline 防闪烁脚本在首帧前读 localStorage 恢复 .dark）
   await page.reload()
   const persistedDark = ((await html.getAttribute('class')) ?? '').includes('dark')
   expect(persistedDark).toBe(afterDark)
+})
+
+test('theme toggle: action icon follows theme (light=moon, dark=sun) + html transition marker class (issue #54)', async ({
+  page,
+  request,
+}) => {
+  // SSR 确定性：预渲染 HTML 输出 moon（服务端快照恒为亮色，水合后更新为实际主题）
+  const prerendered = await (await request.get('/')).text()
+  expect(prerendered).toContain('icons.svg#moon-icon')
+
+  await page.goto('/')
+  const html = page.locator('html')
+  const button = page.getByRole('button', { name: '切换暗色模式' })
+  const icon = button.locator('use')
+
+  // Chromium 支持 View Transitions API：入口脚本首帧前给 <html> 挂过渡标记类
+  // （CSS 以标记门控——标记存在时视觉过渡交给 View Transition，不双重动画）
+  await expect(html).toHaveClass(/theme-vt/)
+
+  // 归一化亮色（初始主题由环境决定，先切到已知状态）
+  if (((await html.getAttribute('class')) ?? '').includes('dark')) {
+    await button.click()
+  }
+  // 亮色 = 月亮图标（动作语义：点击进入暗色）
+  await expect(icon).toHaveAttribute('href', '/icons.svg#moon-icon')
+  await expect(html).toHaveCSS('background-color', 'rgb(255, 255, 255)')
+
+  // 点击 → 暗色：图标变太阳（动作语义：点击进入亮色），背景到达最终态（近黑）
+  await button.click()
+  await expect(icon).toHaveAttribute('href', '/icons.svg#sun-icon')
+  await expect(html).toHaveClass(/dark/)
+  await expect(html).toHaveCSS('background-color', 'rgb(10, 10, 10)')
+
+  // 再点回亮色：图标回月亮，背景回最终态（纯白）
+  await button.click()
+  await expect(icon).toHaveAttribute('href', '/icons.svg#moon-icon')
+  await expect(html).not.toHaveClass(/dark/)
+  await expect(html).toHaveCSS('background-color', 'rgb(255, 255, 255)')
+})
+
+test('theme toggle: class switch is wrapped in startViewTransition when supported (issue #54)', async ({
+  page,
+}) => {
+  await page.goto('/')
+  const html = page.locator('html')
+  const initialDark = ((await html.getAttribute('class')) ?? '').includes('dark')
+
+  // 覆盖 document.startViewTransition 记录调用次数（返回原实现，不影响真实过渡）
+  await page.evaluate(() => {
+    const orig = Document.prototype.startViewTransition.bind(document)
+    let calls = 0
+    Object.defineProperty(document, 'startViewTransition', {
+      configurable: true,
+      value: (cb: () => void) => {
+        calls++
+        return orig(cb)
+      },
+    })
+    ;(window as unknown as { __vtCalls: () => number }).__vtCalls = () => calls
+  })
+
+  await page.getByRole('button', { name: '切换暗色模式' }).click()
+  // startViewTransition 在点击处理器内同步调用（class 切换在其回调内异步执行）
+  expect(
+    await page.evaluate(() => (window as unknown as { __vtCalls: () => number }).__vtCalls()),
+  ).toBe(1)
+  // 整页交叉淡化后 class 翻转到达最终态
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.classList.contains('dark')))
+    .toBe(!initialDark)
+  await expect(html).toHaveCSS(
+    'background-color',
+    initialDark ? 'rgb(255, 255, 255)' : 'rgb(10, 10, 10)',
+  )
+})
+
+test('theme toggle: prefers-reduced-motion switches instantly without startViewTransition (issue #54)', async ({
+  page,
+}) => {
+  const pageErrors: string[] = []
+  page.on('pageerror', (err) => pageErrors.push(err.message))
+
+  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await page.goto('/')
+  const html = page.locator('html')
+
+  // 覆盖 document.startViewTransition 记录调用次数（返回原实现）
+  await page.evaluate(() => {
+    const orig = Document.prototype.startViewTransition.bind(document)
+    let calls = 0
+    Object.defineProperty(document, 'startViewTransition', {
+      configurable: true,
+      value: (cb: () => void) => {
+        calls++
+        return orig(cb)
+      },
+    })
+    ;(window as unknown as { __vtCalls: () => number }).__vtCalls = () => calls
+  })
+
+  const initialDark = ((await html.getAttribute('class')) ?? '').includes('dark')
+  await page.getByRole('button', { name: '切换暗色模式' }).click()
+  // 瞬时切换：点击返回后 class 已翻转（无 View Transition 异步回调等待）
+  const afterDark = ((await html.getAttribute('class')) ?? '').includes('dark')
+  expect(afterDark).not.toBe(initialDark)
+  // reduce 下跳过 startViewTransition（JS 侧不发起过渡）
+  expect(
+    await page.evaluate(() => (window as unknown as { __vtCalls: () => number }).__vtCalls()),
+  ).toBe(0)
+  // 背景色到达最终态（瞬时无动画）
+  await expect(html).toHaveCSS(
+    'background-color',
+    afterDark ? 'rgb(10, 10, 10)' : 'rgb(255, 255, 255)',
+  )
+  expect(pageErrors).toHaveLength(0)
 })
 
 test('prerendered HTML ships the inline no-flash theme script', async ({ request }) => {
@@ -1432,13 +1555,15 @@ test('background texture adapts to theme: light dark-gray, dark light-gray (gray
   expect(css).toContain('%231a1a1a')
   expect(css).toContain('%23e6e6e6')
 
-  // 切换主题后纹理 background-image 随之更新（沿用 dark mode toggle 模式，不依赖初始主题）
+  // 切换主题后纹理 background-image 随之更新（沿用 dark mode toggle 模式，不依赖初始主题）。
+  // issue #54：class 切换在 startViewTransition 回调内异步执行，用轮询等待纹理更新
   await page.goto('/')
   const layer = page.locator('.bg-texture')
   const lightBg = await layer.evaluate((el) => getComputedStyle(el).backgroundImage)
   await page.getByRole('button', { name: '切换暗色模式' }).click()
-  const darkBg = await layer.evaluate((el) => getComputedStyle(el).backgroundImage)
-  expect(darkBg).not.toBe(lightBg)
+  await expect
+    .poll(() => layer.evaluate((el) => getComputedStyle(el).backgroundImage))
+    .not.toBe(lightBg)
 })
 
 test('geek-style OG images are generated and referenced', async ({ request }) => {

--- a/tests/unit/theme-toggle.test.tsx
+++ b/tests/unit/theme-toggle.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { renderToString } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ThemeToggle from '../../src/components/ThemeToggle.tsx'
+
+/**
+ * issue #54：主题切换按钮动作语义图标（亮=moon / 暗=sun）+ startViewTransition 包裹切换。
+ * 单元层覆盖：SSR 确定性输出（服务端快照恒为亮色 → moon，水合后更新为实际主题）、
+ * 图标随 <html> 的 .dark class 翻转（MutationObserver → useSyncExternalStore）、
+ * localStorage 记忆、startViewTransition 包裹（class 在回调内切换）/ 不支持时直接切换、
+ * prefers-reduced-motion 跳过过渡瞬时切换。
+ * （整页交叉淡化、html 过渡标记类由 e2e 断言——见 app.spec.ts issue #54 段。）
+ */
+
+/** jsdom 无 matchMedia（点击处理器会读 prefers-reduced-motion）：默认 stub 为不 reduce */
+function stubMatchMedia(reduced = false) {
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: reduced }))
+}
+
+/** jsdom 原生无 startViewTransition：stub 记录回调列表（class 切换在回调内执行） */
+function stubStartViewTransition(): Array<() => void> {
+  const callbacks: Array<() => void> = []
+  const mock = vi.fn((cb: () => void) => {
+    callbacks.push(cb)
+    return { finished: Promise.resolve() }
+  })
+  Object.defineProperty(document, 'startViewTransition', {
+    configurable: true,
+    value: mock,
+  })
+  return callbacks
+}
+
+function iconName(button: HTMLElement): string | null {
+  return button.querySelector('use')?.getAttribute('href') ?? null
+}
+
+beforeEach(() => {
+  stubMatchMedia(false)
+  document.documentElement.classList.remove('dark')
+  localStorage.clear()
+  // 移除可能的 startViewTransition stub（jsdom 原生无此 API → 回到不支持路径）
+  delete (document as unknown as { startViewTransition?: unknown }).startViewTransition
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('ThemeToggle（issue #54 动作语义图标 + View Transition）', () => {
+  it('SSR 输出确定性：渲染 moon 图标（服务端快照恒为亮色，水合后更新为实际主题）', () => {
+    const html = renderToString(<ThemeToggle />)
+    expect(html).toContain('切换暗色模式')
+    expect(html).toContain('icons.svg#moon-icon')
+    expect(html).not.toContain('icons.svg#sun-icon')
+  })
+
+  it('亮色显示月亮、暗色显示太阳（动作语义：图标 = 切换后进入的主题），图标随 class 翻转', async () => {
+    render(<ThemeToggle />)
+    const button = screen.getByRole('button', { name: '切换暗色模式' })
+    expect(button).toBeInTheDocument()
+    expect(iconName(button)).toContain('moon-icon')
+
+    // 客户端：观察 <html> 的 .dark class，暗色 → 太阳
+    document.documentElement.classList.add('dark')
+    await waitFor(() => expect(iconName(button)).toContain('sun-icon'))
+
+    document.documentElement.classList.remove('dark')
+    await waitFor(() => expect(iconName(button)).toContain('moon-icon'))
+  })
+
+  it('点击切换：翻转 html.dark + localStorage 记忆 + 图标翻转（不支持 View Transition 时直接切换）', async () => {
+    render(<ThemeToggle />)
+    const button = screen.getByRole('button', { name: '切换暗色模式' })
+
+    fireEvent.click(button)
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(localStorage.getItem('theme')).toBe('dark')
+    await waitFor(() => expect(iconName(button)).toContain('sun-icon'))
+
+    fireEvent.click(button)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(localStorage.getItem('theme')).toBe('light')
+    await waitFor(() => expect(iconName(button)).toContain('moon-icon'))
+  })
+
+  it('支持 startViewTransition 且非 reduced-motion：class 切换被包裹在回调内（回调执行后才翻转）', () => {
+    const callbacks = stubStartViewTransition()
+    render(<ThemeToggle />)
+    const button = screen.getByRole('button', { name: '切换暗色模式' })
+
+    fireEvent.click(button)
+    expect(document.startViewTransition).toHaveBeenCalledTimes(1)
+    // 包裹语义：回调尚未执行时 class 未翻转（旧快照先被捕获，整页交叉淡化）
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(callbacks).toHaveLength(1)
+    callbacks.forEach((cb) => cb())
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(localStorage.getItem('theme')).toBe('dark')
+  })
+
+  it('prefers-reduced-motion：跳过 View Transition，直接瞬时切换', () => {
+    stubMatchMedia(true)
+    stubStartViewTransition()
+    render(<ThemeToggle />)
+
+    fireEvent.click(screen.getByRole('button', { name: '切换暗色模式' }))
+    expect(document.startViewTransition).not.toHaveBeenCalled()
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(localStorage.getItem('theme')).toBe('dark')
+  })
+})


### PR DESCRIPTION
Closes #54

## 要构建什么

从访客视角：主题切换按钮从文字「主题」改为图标——亮色模式显示月亮（点击进入暗色）、暗色模式显示太阳（点击进入亮色），一眼看出切换后进入的主题；点击切换时整个页面平滑过渡（View Transitions API 整页交叉淡化，背景纹理与点阵 canvas 均被快照覆盖），不再瞬间变白/变黑；不支持该 API 的浏览器回退 CSS 过渡；系统开启「减少动态效果」时瞬时切换。

从读屏用户视角：按钮保留「切换暗色模式」可访问名称（既有 e2e 与无障碍依赖不回归）。

## 验收标准

- [ ] 按钮按当前主题渲染动作语义图标：亮色=moon、暗色=sun（currentColor 线性符号，随主题灰度自动反色）
- [ ] aria-label「切换暗色模式」与 localStorage 记忆逻辑保持不变
- [ ] SSR/水合无 mismatch（沿用现有主题快照机制：确定性输出，水合后更新为实际主题）
- [ ] 支持 View Transitions API 的浏览器：class 切换被 startViewTransition 包裹，整页交叉淡化无跳变
- [ ] 不支持该 API 的浏览器：CSS 过渡兜底，且与整页交叉淡化不双重动画（入口脚本在支持时给 <html> 挂标记类，CSS 以标记门控）
- [ ] prefers-reduced-motion：JS 侧跳过 View Transition、CSS 侧禁用过渡，瞬时切换
- [ ] e2e 覆盖：图标符号引用随主题切换（亮=moon、暗=sun）、html 过渡标记类、切换后背景色最终态、reduced-motion 瞬时切换
- [ ] 既有「暗色模式切换并持久化」用例零回归

## 阻塞于

无——可以直接开工