### PR TITLE
404 页终端风改进

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -557,6 +557,64 @@ html.dark .terminal-dot--green {
   background: #6e6e6e;
 }
 
+/* ===== 404 页：迷你终端（hero 终端同款视觉：恒黑底白字 + 四角括号） ===== */
+.notfound-terminal {
+  position: relative;
+  margin: 1.5rem 0;
+  border: 1px solid #2b2b2b;
+  background: #000;
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.75;
+}
+.notfound-terminal-body {
+  padding: 1rem 1.125rem 1.25rem;
+  overflow-x: auto;
+}
+/* 命令行：$ 提示符弱化灰阶（装饰性，用户不可选） */
+.notfound-command {
+  margin: 0;
+  color: #d9d9d9;
+}
+.notfound-dollar {
+  color: #8c8c8c;
+  margin-right: 0.5rem;
+  user-select: none;
+}
+/* 响应行：HTTP 404 状态（与命令行同层级弱化） */
+.notfound-response {
+  margin: 0;
+  color: #d9d9d9;
+}
+/* 404 数字：终端的视觉锚点（装饰性，语义由 h1 承担）——大字号 mono 加粗白字 */
+.notfound-code {
+  margin: 0.875rem 0 0;
+  font-size: 3.25rem;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+/* 行尾块状光标：与 hero 终端光标同一几何（宽 0.55em、高 1em），持续闪烁的终端质感 */
+.notfound-cursor {
+  display: inline-block;
+  width: 0.55em;
+  height: 1em;
+  margin-left: 0.15em;
+  background: #fff;
+  animation: notfound-blink 1.1s steps(1) infinite;
+}
+@keyframes notfound-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
 /* ===== 文章列表：连续终端流最后一幕 ===== */
 
 /* 连续终端流容器：--row-start / --row-gap / --row-in 为文章行入场节奏参数 */
@@ -1172,6 +1230,7 @@ html.dark .drawer-panel {
   .terminal-input-cursor,
   .live-dot,
   .terminal-cursor,
+  .notfound-cursor,
   .post-row-enter {
     animation: none;
   }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,11 +1,63 @@
 import { Link } from 'react-router'
 
+import PostRow from '../components/PostRow.tsx'
+import { posts } from '../content/index.ts'
+
+/**
+ * 404 页（catch-all 路由）：h1「页面不存在」+ 迷你终端块（呈现 404 数字，
+ * hero 终端同款视觉：恒黑底白字 + 四角括号）+「返回首页」入口 + 最近 2 篇
+ * 非 draft 文章引导（复用 PostRow，与首页同一内容清单数据源）。误入的访问者
+ * 明确知道页面不存在，并能快速回到内容流，而不是走进死胡同。
+ */
 export default function NotFound() {
+  // 最近文章引导：内容清单按日期倒序（非 draft），取最新 2 篇，与首页同一数据源
+  const recentPosts = posts.slice(0, 2)
+
   return (
-    <div>
-      <h1>404</h1>
-      <p>页面不存在。</p>
-      <Link to="/">返回首页</Link>
+    <div className="mx-auto max-w-2xl">
+      <h1 className="font-mono">页面不存在</h1>
+      <p>地址可能输错了，或链接已经失效。</p>
+
+      {/* 迷你终端块：404 数字为视觉锚点（装饰性，aria-hidden；语义由 h1 承担）。
+          结构沿用 hero 终端：四角括号 + 命令/响应行 + 大号 404 + 行尾闪烁光标 */}
+      <div className="notfound-terminal" role="group" aria-label="错误提示终端">
+        <span className="hero-terminal-corner hero-terminal-corner--tl" aria-hidden="true">
+          ┌
+        </span>
+        <span className="hero-terminal-corner hero-terminal-corner--tr" aria-hidden="true">
+          ┐
+        </span>
+        <div className="notfound-terminal-body">
+          <p className="notfound-command">
+            <span className="notfound-dollar" aria-hidden="true">
+              $
+            </span>
+            GET /missing-page
+          </p>
+          <p className="notfound-response">404 Not Found</p>
+          <p className="notfound-code" aria-hidden="true">
+            404
+            <span className="notfound-cursor" aria-hidden="true" />
+          </p>
+        </div>
+        <span className="hero-terminal-corner hero-terminal-corner--bl" aria-hidden="true">
+          └
+        </span>
+        <span className="hero-terminal-corner hero-terminal-corner--br" aria-hidden="true">
+          ┘
+        </span>
+      </div>
+
+      <p>
+        <Link to="/">返回首页</Link>
+      </p>
+
+      <h2 className="font-mono">最近文章</h2>
+      <ul className="post-row-list">
+        {recentPosts.map((post, i) => (
+          <PostRow key={post.slug} post={post} index={i} />
+        ))}
+      </ul>
     </div>
   )
 }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -703,10 +703,42 @@ test('nav switches between posts list and about page', async ({ page }) => {
   await expect(page.getByText('你好，世界')).toBeVisible()
 })
 
-test('unknown path renders 404', async ({ page }) => {
+test('unknown path renders the terminal-style 404 page: h1 + mini terminal + home link + 2 recent posts (issue #78)', async ({
+  page,
+}) => {
   await page.goto('/definitely-not-a-page')
 
-  await expect(page.getByRole('heading', { name: '404' })).toBeVisible()
+  // h1「页面不存在」（语义标题，替代旧的纯文本三行）——旧 h1 404 不再渲染
+  await expect(page.getByRole('heading', { level: 1, name: '页面不存在' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: '404' })).toHaveCount(0)
+
+  // 迷你终端块：与 hero 终端同一视觉语言（恒黑底白字 + 四角括号），呈现 404 数字
+  const terminal = page.locator('.notfound-terminal')
+  await expect(terminal).toBeVisible()
+  await expect(terminal).toHaveCSS('background-color', 'rgb(0, 0, 0)')
+  await expect(terminal).toHaveCSS('color', 'rgb(255, 255, 255)')
+  expect((await terminal.locator('.hero-terminal-corner').allTextContents()).sort()).toEqual(
+    ['┌', '┐', '└', '┘'].sort(),
+  )
+  await expect(terminal.locator('.notfound-code').getByText('404', { exact: true })).toBeVisible()
+
+  // 「返回首页」入口：指向 /
+  const homeLink = page.getByRole('link', { name: '返回首页' })
+  await expect(homeLink).toBeVisible()
+  await expect(homeLink).toHaveAttribute('href', '/')
+
+  // 最近 2 篇非 draft 文章引导：复用文章行组件（与首页同一内容清单数据源），期望值从源计算
+  const recent = publishedPosts().slice(0, 2)
+  const rows = page.locator('.post-row')
+  await expect(rows).toHaveCount(2)
+  for (const post of recent) {
+    await expect(rows.filter({ hasText: post.title })).toBeVisible()
+  }
+
+  // 点击最近文章：正常跳转到文章页
+  await rows.first().click()
+  await expect(page).toHaveURL(new RegExp(`/posts/${recent[0]?.slug}`))
+  await expect(page.getByRole('heading', { name: recent[0]?.title ?? '' })).toBeVisible()
 })
 
 test('raw HTML source contains article title without executing JS', async ({ request }) => {


### PR DESCRIPTION
Closes #78

## 要构建什么

访问不存在的路径（手输错误、旧链接失效等）命中 catch-all 路由时，渲染一个与全站终端风视觉一致的 404 页：h1 标题「页面不存在」+ 迷你终端块呈现 404 数字 + 「返回首页」入口 + 最近 2 篇文章引导（复用文章行组件，与首页同一内容清单数据源）。误入的访问者能明确知道页面不存在，并能快速回到内容流，而不是走进死胡同。

dev 与构建产物行为一致；RSS 修复工单（阻塞链下游）落地后，正常的订阅入口不再命中此页，但任意未知路径仍会走到这里。

## 验收标准

- [ ] 访问任意未知路径（dev 与构建产物）渲染新 404 页，而非旧的纯文本三行
- [ ] 页面含 h1「页面不存在」、迷你终端块（呈现 404 数字）、「返回首页」链接
- [ ] 页面展示最近 2 篇非草稿文章链接，点击可正常跳转
- [ ] 新增 e2e 断言覆盖 404 页可见产出（沿用现有 e2e 体系，不加新接缝）
- [ ] `pnpm test` / `pnpm typecheck` / `pnpm lint` 全绿

## 阻塞于

- 无——可以直接开工

---
参考 PRD：[PRD：dev 模式 RSS 订阅源与 404 页改进](https://my.feishu.cn/docx/IqMQdhn1Do7suIxYaICcmx82nah)