### PR TITLE
dev 模式提供真实 RSS 订阅源（vite 插件）

### DIFF
--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -7,6 +7,7 @@ import { StaticRouter } from 'react-router'
 
 import { AppRoutes } from '../src/App.tsx'
 import { posts } from '../src/content/posts.ts'
+import { escapeXml, generateFeed } from '../src/feed.ts'
 import { siteName, siteUrl, tagline } from '../src/site.ts'
 
 // 构建期预渲染：对每个路由执行 renderToString（StaticRouter 与客户端
@@ -210,48 +211,9 @@ Sitemap: ${siteUrl}/sitemap.xml
 `
 writeFileSync(join(distDir, 'robots.txt'), robots)
 
-// feed.xml：RSS 2.0，条目含全文（content:encoded）；draft 已由内容清单过滤，不进入 feed
-function escapeXml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-}
-
-/** YYYY-MM-DD → RFC 2822（RSS pubDate，UTC） */
-function toRfc2822(date: string): string {
-  const [year, month, day] = date.split('-').map(Number)
-  return new Date(Date.UTC(year as number, (month as number) - 1, day as number))
-    .toUTCString()
-    .replace('GMT', '+0000')
-}
-
-const feedItems = posts
-  .map(
-    (post) => `  <item>
-    <title>${escapeXml(post.title)}</title>
-    <link>${siteUrl}/posts/${post.slug}</link>
-    <guid isPermaLink="true">${siteUrl}/posts/${post.slug}</guid>
-    <pubDate>${toRfc2822(post.date)}</pubDate>
-    <description>${escapeXml(post.description)}</description>
-    <content:encoded><![CDATA[${post.html}]]></content:encoded>
-  </item>`,
-  )
-  .join('\n')
-
-const feed = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
-  <channel>
-    <title>${escapeXml(siteName)}</title>
-    <link>${siteUrl}/</link>
-    <description>${escapeXml(tagline)}</description>
-    <language>zh-CN</language>
-${feedItems}
-  </channel>
-</rss>
-`
-writeFileSync(join(distDir, 'feed.xml'), feed)
+// feed.xml：RSS 2.0，条目含全文（content:encoded）；draft 已由内容清单过滤，不进入 feed。
+// 生成逻辑收敛在共享模块 src/feed.ts（与 dev 中间件同一实现，格式保证一致）。
+writeFileSync(join(distDir, 'feed.xml'), generateFeed(posts, siteUrl, siteName, tagline))
 
 // 极客风 OG 图：首页 + 每篇非 draft 文章各生成一张（黑白灰阶 + mono + 标题）
 const ogDir = join(distDir, 'og', 'posts')

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -1,0 +1,61 @@
+import type { Post } from './content/types.ts'
+
+/**
+ * 共享 feed 生成模块（issue #79）：生产构建（scripts/prerender）与
+ * dev 中间件（vite-feed-plugin）共用同一实现，保证两处 feed 格式一致。
+ * 纯函数、无副作用；草稿过滤由调用方负责（loadPosts includeDrafts: false）。
+ */
+
+/** XML 特殊字符转义（& 必须最先替换，避免二次转义） */
+export function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+/** YYYY-MM-DD → RFC 2822（RSS pubDate，UTC） */
+export function toRfc2822(date: string): string {
+  const [year, month, day] = date.split('-').map(Number)
+  return new Date(Date.UTC(year as number, (month as number) - 1, day as number))
+    .toUTCString()
+    .replace('GMT', '+0000')
+}
+
+/**
+ * 生成 RSS 2.0 feed：channel 元信息 + 全文条目（content:encoded）。
+ * baseUrl 不带尾斜杠（生产 = siteUrl，dev = 当前 origin），
+ * 条目链接为 baseUrl/posts/<slug>。
+ */
+export function generateFeed(
+  posts: Post[],
+  baseUrl: string,
+  channelTitle: string,
+  channelDescription: string,
+): string {
+  const feedItems = posts
+    .map(
+      (post) => `  <item>
+    <title>${escapeXml(post.title)}</title>
+    <link>${baseUrl}/posts/${post.slug}</link>
+    <guid isPermaLink="true">${baseUrl}/posts/${post.slug}</guid>
+    <pubDate>${toRfc2822(post.date)}</pubDate>
+    <description>${escapeXml(post.description)}</description>
+    <content:encoded><![CDATA[${post.html}]]></content:encoded>
+  </item>`,
+    )
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>${escapeXml(channelTitle)}</title>
+    <link>${baseUrl}/</link>
+    <description>${escapeXml(channelDescription)}</description>
+    <language>zh-CN</language>
+${feedItems}
+  </channel>
+</rss>
+`
+}

--- a/tests/fixtures/feed/draft.md
+++ b/tests/fixtures/feed/draft.md
@@ -1,0 +1,9 @@
+---
+title: 草稿标题 Draft
+date: 2026-08-09
+description: 不应出现在 feed。
+tags: [测试]
+draft: true
+---
+
+草稿正文。

--- a/tests/fixtures/feed/published.md
+++ b/tests/fixtures/feed/published.md
@@ -1,0 +1,8 @@
+---
+title: 'A & B <Tag> "Quote"'
+date: 2026-08-10
+description: 'desc & more <info>'
+tags: [测试]
+---
+
+正文包含 **粗体** 与 `inline code`。

--- a/tests/unit/feed-plugin.test.ts
+++ b/tests/unit/feed-plugin.test.ts
@@ -1,0 +1,121 @@
+import type { ServerResponse } from 'node:http'
+import type { Connect } from 'vite'
+
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { handleFeedRequest } from '../../vite-feed-plugin.ts'
+
+const FEED_FIXTURE_DIR = join(process.cwd(), 'tests', 'fixtures', 'feed')
+
+/**
+ * issue #79：dev 模式真实 RSS 订阅源。本次唯一的新测试接缝——
+ * mock req/res 直测 handleFeedRequest（HTTP 处理器），不启动 dev server。
+ */
+
+function mockReq(method: string, url: string): Connect.IncomingMessage {
+  return { method, url, headers: { host: 'localhost:5173' } } as unknown as Connect.IncomingMessage
+}
+
+function mockRes() {
+  const headers = new Map<string, string>()
+  const res = {
+    statusCode: 0,
+    body: '',
+    ended: false,
+    setHeader(name: string, value: string) {
+      headers.set(name, value)
+    },
+    getHeader(name: string) {
+      return headers.get(name)
+    },
+    end(chunk?: unknown) {
+      if (chunk !== undefined && chunk !== null) this.body = String(chunk)
+      this.ended = true
+    },
+  }
+  return res as unknown as ServerResponse & {
+    body: string
+    ended: boolean
+    getHeader: (name: string) => string | undefined
+  }
+}
+
+const HANDLER_OPTIONS = { baseUrl: 'http://localhost:5173', postsDir: FEED_FIXTURE_DIR }
+
+describe('handleFeedRequest: GET /feed.xml → RSS 2.0 feed（mock req/res 直测）', () => {
+  it('返回 200 + application/rss+xml; charset=utf-8，正文为 RSS 2.0 channel 结构', async () => {
+    const res = mockRes()
+    const handled = await handleFeedRequest(mockReq('GET', '/feed.xml'), res, HANDLER_OPTIONS)
+
+    expect(handled).toBe(true)
+    expect(res.statusCode).toBe(200)
+    expect(res.getHeader('Content-Type')).toBe('application/rss+xml; charset=utf-8')
+    expect(res.ended).toBe(true)
+
+    const body = res.body
+    expect(body).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(body).toContain(
+      '<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">',
+    )
+    expect(body).toContain('  <channel>')
+    expect(body).toContain('<title>Hacxy</title>')
+    expect(body).toContain('<link>http://localhost:5173/</link>')
+    expect(body).toContain('<language>zh-CN</language>')
+  })
+
+  it('条目链接指向 base URL（dev 站点当前 origin）', async () => {
+    const res = mockRes()
+    await handleFeedRequest(mockReq('GET', '/feed.xml'), res, HANDLER_OPTIONS)
+
+    expect(res.body).toContain('<link>http://localhost:5173/posts/published</link>')
+    expect(res.body).toContain(
+      '<guid isPermaLink="true">http://localhost:5173/posts/published</guid>',
+    )
+  })
+
+  it('草稿文章不进入 feed', async () => {
+    const res = mockRes()
+    await handleFeedRequest(mockReq('GET', '/feed.xml'), res, HANDLER_OPTIONS)
+
+    expect(res.body).not.toContain('草稿标题')
+    expect(res.body).not.toContain('不应出现在 feed')
+  })
+
+  it('title/description 特殊字符正确转义（& < > "）', async () => {
+    const res = mockRes()
+    await handleFeedRequest(mockReq('GET', '/feed.xml'), res, HANDLER_OPTIONS)
+
+    expect(res.body).toContain('<title>A &amp; B &lt;Tag&gt; &quot;Quote&quot;</title>')
+    expect(res.body).toContain('<description>desc &amp; more &lt;info&gt;</description>')
+  })
+
+  it('正文全文进入 content:encoded CDATA，与生产格式一致', async () => {
+    const res = mockRes()
+    await handleFeedRequest(mockReq('GET', '/feed.xml'), res, HANDLER_OPTIONS)
+
+    expect(res.body).toContain('<content:encoded><![CDATA[')
+    expect(res.body).toContain(']]></content:encoded>')
+    expect(res.body).toContain(
+      '<p>正文包含 <strong>粗体</strong> 与 <code>inline code</code>。</p>',
+    )
+  })
+
+  it('pubDate 为 RFC 2822（UTC +0000）', async () => {
+    const res = mockRes()
+    await handleFeedRequest(mockReq('GET', '/feed.xml'), res, HANDLER_OPTIONS)
+
+    expect(res.body).toContain('<pubDate>Mon, 10 Aug 2026 00:00:00 +0000</pubDate>')
+  })
+
+  it('仅精确命中 GET /feed.xml：其他路径/方法不处理', async () => {
+    const res = mockRes()
+    expect(await handleFeedRequest(mockReq('GET', '/other'), res, HANDLER_OPTIONS)).toBe(false)
+    expect(await handleFeedRequest(mockReq('GET', '/feed.xml/'), res, HANDLER_OPTIONS)).toBe(false)
+    expect(await handleFeedRequest(mockReq('GET', '/feed.xmlish'), res, HANDLER_OPTIONS)).toBe(
+      false,
+    )
+    expect(await handleFeedRequest(mockReq('POST', '/feed.xml'), res, HANDLER_OPTIONS)).toBe(false)
+    expect(res.ended).toBe(false)
+  })
+})

--- a/vite-feed-plugin.ts
+++ b/vite-feed-plugin.ts
@@ -1,0 +1,74 @@
+import type { ServerResponse } from 'node:http'
+import type { Connect, Plugin, ViteDevServer } from 'vite'
+
+import { join } from 'node:path'
+
+import { collectPostSources } from './src/content/collectSources.ts'
+import { loadPosts } from './src/content/loadPosts.ts'
+import { generateFeed } from './src/feed.ts'
+import { siteName, siteUrl, tagline } from './src/site.ts'
+
+const POSTS_DIR = join(process.cwd(), 'content', 'posts')
+const FEED_PATH = '/feed.xml'
+
+export interface FeedHandlerOptions {
+  /** feed 条目链接的站点地址（dev = 当前 origin，如 http://localhost:5173），不带尾斜杠 */
+  baseUrl: string
+  /** 文章目录（单测注入 fixture；默认 content/posts） */
+  postsDir?: string
+}
+
+/**
+ * dev feed HTTP 处理器（单测 mock req/res 直测的接缝）：
+ * 仅精确命中 GET /feed.xml（query 不影响）时生成并响应 feed，其余请求返回
+ * false 交还中间件链。草稿经 loadPosts 过滤（永不进入 feed）；每次请求
+ * 重新聚合内容，新增/修改文章无需重启 dev。
+ */
+export async function handleFeedRequest(
+  req: Connect.IncomingMessage,
+  res: ServerResponse,
+  options: FeedHandlerOptions,
+): Promise<boolean> {
+  if (req.method !== 'GET') return false
+  const pathname = (req.url ?? '').split('?')[0] ?? ''
+  if (pathname !== FEED_PATH) return false
+  const posts = await loadPosts(collectPostSources(options.postsDir ?? POSTS_DIR), {
+    includeDrafts: false,
+  })
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8')
+  res.end(generateFeed(posts, options.baseUrl, siteName, tagline))
+  return true
+}
+
+/** dev 站点当前 origin（http://localhost:<port>，不带尾斜杠）；回退 Host 头 / 生产地址 */
+function resolveDevOrigin(server: ViteDevServer, req: Connect.IncomingMessage): string {
+  const local = server.resolvedUrls?.local[0]
+  if (local) return local.replace(/\/$/, '')
+  const host = req.headers.host
+  return host ? `http://${host}` : siteUrl
+}
+
+/**
+ * dev 专用 RSS 插件：configureServer 中间件先于 SPA fallback 生效，
+ * 仅拦截精确路径 /feed.xml，按需生成与生产一致的 feed（条目链接用当前
+ * origin，点击即打开对应文章）。无构建期钩子——生产 feed 仍由
+ * scripts/prerender 发射，插件不影响构建产物。
+ */
+export function feedPlugin(): Plugin {
+  return {
+    name: 'dev-feed',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        void handleFeedRequest(req, res, {
+          baseUrl: resolveDevOrigin(server, req),
+        }).then(
+          (handled) => {
+            if (!handled) next()
+          },
+          (error) => next(error),
+        )
+      })
+    },
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,11 +3,19 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
 import { postAssetsPlugin } from './vite-assets-plugin.ts'
+import { feedPlugin } from './vite-feed-plugin.ts'
 import { postsPlugin } from './vite-posts-plugin.ts'
 import { siteMetaPlugin } from './vite-site-meta-plugin.ts'
 
 export default defineConfig({
-  plugins: [react(), tailwindcss(), postsPlugin(), postAssetsPlugin(), siteMetaPlugin()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    postsPlugin(),
+    feedPlugin(),
+    postAssetsPlugin(),
+    siteMetaPlugin(),
+  ],
   server: {
     watch: {
       // 排除 pi-afk 运行时产物（.pi/afk/worktrees 等），避免 .html 文件触发整页 reload


### PR DESCRIPTION
Closes #79

## 要构建什么

开发模式（`pnpm dev`）下，顶部导航栏右侧的 RSS 订阅按钮点击后能打开**真实的订阅源**，不再跳转 404 页。dev 服务器按需生成并返回 `/feed.xml`（`application/rss+xml`），格式与生产构建产物一致（RSS 2.0 channel + 全文 `content:encoded` 条目）；条目链接指向 dev 站点当前 origin，点击即可打开对应文章；草稿文章永不出现；新增/修改文章后无需重启 dev 即反映最新内容。

实现上复用共享 feed 生成模块（阻塞链上游工单产出）新增一个 dev 专用 vite 插件（沿用仓库既有插件模式），仅拦截精确路径 `/feed.xml`、先于 SPA fallback 生效；插件不接管构建期发射，生产 feed 行为不受影响。

## 验收标准

- [ ] `pnpm dev` 下访问 `/feed.xml` 返回 200 + `application/rss+xml; charset=utf-8`
- [ ] feed 结构与生产一致：channel 元信息 + 全文条目，特殊字符正确转义
- [ ] 条目链接指向 dev 站点当前 origin（如 `http://localhost:<port>/posts/...`），点击可打开对应文章
- [ ] 草稿文章不进入 dev feed
- [ ] 新增/修改文章后无需重启 dev，feed 反映最新内容
- [ ] 单测覆盖插件 HTTP 处理器（mock req/res 直测，不启 dev server）：状态码、Content-Type、正文结构、草稿过滤、转义、base URL——此为本次唯一的**新测试接缝**
- [ ] `pnpm test` / `pnpm typecheck` / `pnpm lint` 全绿；`pnpm build` 后生产 feed 仍与基线逐字节一致

## 阻塞于

- #77 — 抽取共享 feed 生成模块（prefactor）

---
参考 PRD：[PRD：dev 模式 RSS 订阅源与 404 页改进](https://my.feishu.cn/docx/IqMQdhn1Do7suIxYaICcmx82nah)