### PR TITLE
抽取共享 feed 生成模块（prefactor）

### DIFF
--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -6,6 +6,7 @@ import { renderToString } from 'react-dom/server'
 import { StaticRouter } from 'react-router'
 
 import { AppRoutes } from '../src/App.tsx'
+import { escapeXml, renderFeed } from '../src/content/feed.ts'
 import { posts } from '../src/content/posts.ts'
 import { siteName, siteUrl, tagline } from '../src/site.ts'
 
@@ -210,48 +211,10 @@ Sitemap: ${siteUrl}/sitemap.xml
 `
 writeFileSync(join(distDir, 'robots.txt'), robots)
 
-// feed.xml：RSS 2.0，条目含全文（content:encoded）；draft 已由内容清单过滤，不进入 feed
-function escapeXml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-}
-
-/** YYYY-MM-DD → RFC 2822（RSS pubDate，UTC） */
-function toRfc2822(date: string): string {
-  const [year, month, day] = date.split('-').map(Number)
-  return new Date(Date.UTC(year as number, (month as number) - 1, day as number))
-    .toUTCString()
-    .replace('GMT', '+0000')
-}
-
-const feedItems = posts
-  .map(
-    (post) => `  <item>
-    <title>${escapeXml(post.title)}</title>
-    <link>${siteUrl}/posts/${post.slug}</link>
-    <guid isPermaLink="true">${siteUrl}/posts/${post.slug}</guid>
-    <pubDate>${toRfc2822(post.date)}</pubDate>
-    <description>${escapeXml(post.description)}</description>
-    <content:encoded><![CDATA[${post.html}]]></content:encoded>
-  </item>`,
-  )
-  .join('\n')
-
-const feed = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
-  <channel>
-    <title>${escapeXml(siteName)}</title>
-    <link>${siteUrl}/</link>
-    <description>${escapeXml(tagline)}</description>
-    <language>zh-CN</language>
-${feedItems}
-  </channel>
-</rss>
-`
-writeFileSync(join(distDir, 'feed.xml'), feed)
+// feed.xml：RSS 2.0，条目含全文（content:encoded）。组装逻辑（XML 转义 / RFC 2822
+// 日期 / 频道条目 / 草稿过滤）收敛于共享模块 src/content/feed.ts（issue #77），
+// dev 与生产共用同一草稿策略；OG 图 SVG 继续复用共享 escapeXml。
+writeFileSync(join(distDir, 'feed.xml'), renderFeed(posts, { siteName, siteUrl, tagline }))
 
 // 极客风 OG 图：首页 + 每篇非 draft 文章各生成一张（黑白灰阶 + mono + 标题）
 const ogDir = join(distDir, 'og', 'posts')

--- a/src/content/feed.ts
+++ b/src/content/feed.ts
@@ -1,0 +1,61 @@
+import type { Post } from './types.ts'
+
+/**
+ * 共享 feed 生成模块（issue #77 prefactor）：RSS 2.0 订阅源（feed.xml）的
+ * 组装逻辑——XML 转义 / RFC 2822 日期 / 频道与条目组装 / 草稿过滤——
+ * 全部收敛为纯函数。预渲染脚本与 dev 订阅源（下游工单）共用同一实现，
+ * dev 与生产共用同一草稿策略：草稿不进入 feed（renderFeed 是唯一过滤点）。
+ */
+
+/** XML 文本转义：& < > " 替换为实体（feed.xml 与 OG 图 SVG 共用） */
+export function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+/** YYYY-MM-DD → RFC 2822（RSS pubDate，UTC） */
+export function toRfc2822(date: string): string {
+  const [year, month, day] = date.split('-').map(Number)
+  return new Date(Date.UTC(year as number, (month as number) - 1, day as number))
+    .toUTCString()
+    .replace('GMT', '+0000')
+}
+
+/** feed 频道元信息（来自站点配置，调用方传入以便测试与 dev 复用） */
+export interface FeedChannel {
+  siteName: string
+  siteUrl: string
+  tagline: string
+}
+
+/** 组装 RSS 2.0 feed.xml：draft 过滤唯一执行点（草稿不进入 feed，dev 与生产共用） */
+export function renderFeed(posts: Post[], channel: FeedChannel): string {
+  const items = posts
+    .filter((post) => !post.draft)
+    .map(
+      (post) => `  <item>
+    <title>${escapeXml(post.title)}</title>
+    <link>${channel.siteUrl}/posts/${post.slug}</link>
+    <guid isPermaLink="true">${channel.siteUrl}/posts/${post.slug}</guid>
+    <pubDate>${toRfc2822(post.date)}</pubDate>
+    <description>${escapeXml(post.description)}</description>
+    <content:encoded><![CDATA[${post.html}]]></content:encoded>
+  </item>`,
+    )
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>${escapeXml(channel.siteName)}</title>
+    <link>${channel.siteUrl}/</link>
+    <description>${escapeXml(channel.tagline)}</description>
+    <language>zh-CN</language>
+${items}
+  </channel>
+</rss>
+`
+}

--- a/tests/unit/feed.test.ts
+++ b/tests/unit/feed.test.ts
@@ -1,0 +1,112 @@
+import type { Post } from '../../src/content/types.ts'
+
+import { describe, expect, it } from 'vitest'
+
+import { escapeXml, renderFeed, toRfc2822 } from '../../src/content/feed.ts'
+
+/**
+ * issue #77（prefactor）：feed.xml 组装逻辑抽为共享纯函数模块
+ * （src/content/feed.ts）——XML 转义 / RFC 2822 日期 / 频道与条目组装 /
+ * 草稿过滤全部收敛于此；预渲染脚本与后续 dev 订阅源共用同一实现，
+ * dev 与生产共用同一草稿策略（草稿不进入 feed）。
+ */
+
+function post(overrides: Partial<Post>): Post {
+  return {
+    slug: 'hello',
+    title: '你好，世界',
+    date: '2026-08-10',
+    description: '',
+    tags: [],
+    draft: false,
+    html: '<p>正文</p>',
+    toc: [],
+    ...overrides,
+  }
+}
+
+describe('escapeXml（feed 与 OG 图 SVG 共用）', () => {
+  it('escapes & < > " to XML entities', () => {
+    expect(escapeXml('a & b < c > d " e')).toBe('a &amp; b &lt; c &gt; d &quot; e')
+  })
+
+  it('leaves plain text and CJK untouched', () => {
+    expect(escapeXml('了解真相，才能获得真正的自由')).toBe('了解真相，才能获得真正的自由')
+  })
+})
+
+describe('toRfc2822（RSS pubDate，UTC）', () => {
+  it('converts YYYY-MM-DD to RFC 2822 with +0000 offset', () => {
+    expect(toRfc2822('2026-08-10')).toBe('Mon, 10 Aug 2026 00:00:00 +0000')
+    expect(toRfc2822('2026-08-11')).toBe('Tue, 11 Aug 2026 00:00:00 +0000')
+    expect(toRfc2822('2026-08-12')).toBe('Wed, 12 Aug 2026 00:00:00 +0000')
+    expect(toRfc2822('2026-01-01')).toBe('Thu, 01 Jan 2026 00:00:00 +0000')
+  })
+})
+
+describe('renderFeed（RSS 2.0 组装）', () => {
+  const channel = { siteName: 'Hacxy', siteUrl: 'https://hacxy.cn', tagline: '副标题' }
+
+  it('renders channel + item with full content and exact byte layout', () => {
+    const feed = renderFeed(
+      [post({ slug: 'hello', title: '你好，世界', date: '2026-08-10' })],
+      channel,
+    )
+    expect(feed).toBe(`<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Hacxy</title>
+    <link>https://hacxy.cn/</link>
+    <description>副标题</description>
+    <language>zh-CN</language>
+  <item>
+    <title>你好，世界</title>
+    <link>https://hacxy.cn/posts/hello</link>
+    <guid isPermaLink="true">https://hacxy.cn/posts/hello</guid>
+    <pubDate>Mon, 10 Aug 2026 00:00:00 +0000</pubDate>
+    <description></description>
+    <content:encoded><![CDATA[<p>正文</p>]]></content:encoded>
+  </item>
+  </channel>
+</rss>
+`)
+  })
+
+  it('escapes XML special chars in title/description', () => {
+    const feed = renderFeed(
+      [
+        post({
+          title: 'a < b & "c" > d',
+          description: '说明 <code>x</code> & more',
+        }),
+      ],
+      channel,
+    )
+    expect(feed).toContain('<title>a &lt; b &amp; &quot;c&quot; &gt; d</title>')
+    expect(feed).toContain('<description>说明 &lt;code&gt;x&lt;/code&gt; &amp; more</description>')
+  })
+
+  it('filters drafts: draft posts never enter the feed', () => {
+    const feed = renderFeed(
+      [
+        post({ slug: 'published', title: '正式文章' }),
+        post({ slug: 'draft', title: '草稿', draft: true }),
+      ],
+      channel,
+    )
+    expect(feed).toContain('https://hacxy.cn/posts/published')
+    expect(feed).not.toContain('draft')
+    expect(feed).not.toContain('草稿')
+  })
+
+  it('keeps caller-provided order (no hidden sorting)', () => {
+    const feed = renderFeed(
+      [post({ slug: 'second', date: '2026-08-01' }), post({ slug: 'first', date: '2026-08-10' })],
+      channel,
+    )
+    const second = feed.indexOf('posts/second')
+    const first = feed.indexOf('posts/first')
+    expect(second).toBeGreaterThan(-1)
+    expect(first).toBeGreaterThan(second)
+  })
+})


### PR DESCRIPTION
Closes #77

## 要构建什么

把 RSS 2.0 订阅源（feed.xml）的组装逻辑——XML 转义、RFC 2822 日期转换、频道/条目组装、草稿过滤——从预渲染脚本中抽成独立的共享纯函数模块；预渲染脚本删除本地重复实现，改为调用共享模块。这是纯重构：**生产构建产物的 feed.xml 与重构前逐字节一致**，线上订阅源无任何变化；dev 侧行为也保持不变（此时 dev 仍无订阅源，属现状）。

抽出的共享模块是后续 dev 订阅源（见阻塞链下游工单）复用的基础——草稿过滤收敛为生成函数的单一执行点。

## 验收标准

- [ ] 重构前留存当前构建产物 feed.xml 基线；重构后 `pnpm build` 生成的 feed.xml 与基线逐字节一致
- [ ] 共享生成函数统一执行草稿过滤（草稿文章不进入 feed，dev 与生产共用同一策略）
- [ ] 预渲染脚本中重复的转义/日期/组装实现被删除，仅保留对共享模块的调用；OG 图渲染继续复用共享的 XML 转义函数
- [ ] `pnpm typecheck` / `pnpm lint` / `pnpm test` 全绿

## 阻塞于

- 无——可以直接开工

---
参考 PRD：[PRD：dev 模式 RSS 订阅源与 404 页改进](https://my.feishu.cn/docx/IqMQdhn1Do7suIxYaICcmx82nah)